### PR TITLE
fix: 避免 BEpusdt 回调长时间占用数据库事务

### DIFF
--- a/app/task/notify/notify.go
+++ b/app/task/notify/notify.go
@@ -19,6 +19,7 @@ import (
 	"github.com/v03413/bepusdt/app/utils"
 
 	"github.com/v03413/go-cache"
+	"gorm.io/gorm"
 )
 
 type EpNotify struct {
@@ -166,88 +167,79 @@ func Bepusdt(o model.Order) {
 		return
 	}
 
-	var todo = func() error {
-		var db = model.Db.Begin()
-		if err := db.Where("trade_id = ? and status = ?", o.TradeId, o.Status).Limit(1).Find(&o).Error; err != nil {
-			db.Rollback()
-
-			return err
-		}
-
-		var key = fmt.Sprintf("bepusdt_notify_%d_%s", o.Status, o.TradeId)
-		if _, ok := cache.Get(key); ok {
-			db.Rollback()
-
-			return nil
-		}
-
-		cache.Set(key, true, time.Minute)
-
-		var data = make(map[string]interface{})
-		var body = EpNotify{
-			TradeId:            o.TradeId,
-			OrderId:            o.OrderId,
-			Amount:             cast.ToFloat64(o.Money),
-			ActualAmount:       o.Amount,
-			Token:              o.Address,
-			BlockTransactionId: o.RefHash,
-			Status:             o.Status,
-		}
-		var jsonBody, err = json.Marshal(body)
-		if err != nil {
-			db.Rollback()
-
-			return err
-		}
-
-		if err = json.Unmarshal(jsonBody, &data); err != nil {
-			db.Rollback()
-
-			return err
-		}
-
-		// 签名
-		body.Signature = utils.EpusdtSign(data, model.AuthToken())
-
-		// 再次序列化
-		jsonBody, _ = json.Marshal(body)
-		var client = http.Client{Timeout: time.Second * 5}
-		var req, err2 = http.NewRequest("POST", o.NotifyUrl, strings.NewReader(string(jsonBody)))
-		if err2 != nil {
-			db.Rollback()
-
-			return err2
-		}
-
-		req.Header.Set("Content-Type", "application/json")
-		req.Header.Set("Powered-By", "https://github.com/v03413/BEpusdt")
-		resp, err := client.Do(req)
-		if err != nil {
-			db.Rollback()
-
-			return err
-		}
-
-		defer resp.Body.Close()
-		if resp.StatusCode != 200 {
-			db.Rollback()
-
-			return fmt.Errorf("resp.StatusCode != 200")
-		}
-
-		all, _ := io.ReadAll(resp.Body)
-
-		log.Info(fmt.Sprintf("订单回调成功[%d]：%s %s", o.Status, o.TradeId, string(all)))
-
-		db.Commit()
-
-		return nil
-	}
+	var authToken = model.AuthToken()
+	var client = &http.Client{Timeout: time.Second * 5}
 	go func() {
-		if err := todo(); err != nil {
+		if err := deliverBepusdtStatusUpdate(model.Db, client, authToken, o); err != nil {
 			log.Warn("notify BEpusdt Error:", err.Error())
 		}
 	}()
+}
+
+func deliverBepusdtStatusUpdate(db *gorm.DB, client *http.Client, authToken string, o model.Order) error {
+	if client == nil {
+		client = &http.Client{Timeout: time.Second * 5}
+	}
+
+	var current model.Order
+	tx := db.Where("trade_id = ? and status = ?", o.TradeId, o.Status).Limit(1).Find(&current)
+	if tx.Error != nil {
+		return tx.Error
+	}
+	if tx.RowsAffected == 0 {
+		return nil
+	}
+
+	var key = fmt.Sprintf("bepusdt_notify_%d_%s", current.Status, current.TradeId)
+	if _, ok := cache.Get(key); ok {
+		return nil
+	}
+
+	cache.Set(key, true, time.Minute)
+
+	var data = make(map[string]interface{})
+	var body = EpNotify{
+		TradeId:            current.TradeId,
+		OrderId:            current.OrderId,
+		Amount:             cast.ToFloat64(current.Money),
+		ActualAmount:       current.Amount,
+		Token:              current.Address,
+		BlockTransactionId: current.RefHash,
+		Status:             current.Status,
+	}
+	jsonBody, err := json.Marshal(body)
+	if err != nil {
+		return err
+	}
+
+	if err = json.Unmarshal(jsonBody, &data); err != nil {
+		return err
+	}
+
+	body.Signature = utils.EpusdtSign(data, authToken)
+
+	jsonBody, _ = json.Marshal(body)
+	req, err := http.NewRequest("POST", current.NotifyUrl, strings.NewReader(string(jsonBody)))
+	if err != nil {
+		return err
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Powered-By", "https://github.com/v03413/BEpusdt")
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		return fmt.Errorf("resp.StatusCode != 200")
+	}
+
+	all, _ := io.ReadAll(resp.Body)
+	log.Info(fmt.Sprintf("订单回调成功[%d]：%s %s", current.Status, current.TradeId, string(all)))
+
+	return nil
 }
 
 func markNotifyFail(o model.Order, reason string) {

--- a/app/task/notify/notify_test.go
+++ b/app/task/notify/notify_test.go
@@ -1,0 +1,123 @@
+package notify
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+	"time"
+
+	applog "github.com/v03413/bepusdt/app/log"
+	"github.com/glebarez/sqlite"
+	"github.com/v03413/bepusdt/app/model"
+	"gorm.io/gorm"
+)
+
+func newNotifyTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+
+	dbPath := filepath.Join(t.TempDir(), "notify-test.db")
+	db, err := gorm.Open(sqlite.Open(dbPath+"?cache=shared&mode=rwc&_pragma=journal_mode(WAL)&_pragma=busy_timeout(1000)"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open test db: %v", err)
+	}
+
+	sqlDB, err := db.DB()
+	if err != nil {
+		t.Fatalf("get sql db: %v", err)
+	}
+	sqlDB.SetMaxOpenConns(1)
+	sqlDB.SetMaxIdleConns(1)
+
+	if err := db.AutoMigrate(&model.Order{}); err != nil {
+		t.Fatalf("auto migrate order: %v", err)
+	}
+
+	return db
+}
+
+func initNotifyTestLog(t *testing.T) {
+	t.Helper()
+
+	if err := applog.Init(filepath.Join(t.TempDir(), "logs")); err != nil {
+		t.Fatalf("init log: %v", err)
+	}
+	t.Cleanup(func() {
+		applog.Close()
+	})
+}
+
+func newWaitingOrder(notifyURL string) model.Order {
+	now := time.Now()
+	confirmedAt := now
+
+	return model.Order{
+		OrderId:       "merchant-order-1",
+		TradeId:       "trade-order-1",
+		TradeType:     model.UsdtTrc20,
+		Fiat:          "CNY",
+		Crypto:        "USDT",
+		Rate:          "7.00",
+		Amount:        "1.00",
+		Money:         "7.00",
+		Address:       "TTestAddress1234567890",
+		Status:        model.OrderStatusWaiting,
+		ApiType:       model.OrderApiTypeEpusdt,
+		NotifyUrl:     notifyURL,
+		ExpiredAt:     now.Add(10 * time.Minute),
+		ConfirmedAt:   &confirmedAt,
+		AutoTimeAt:    model.AutoTimeAt{CreatedAt: (*model.Datetime)(&now), UpdatedAt: (*model.Datetime)(&now)},
+	}
+}
+
+func TestDeliverBepusdtStatusUpdateDoesNotHoldDBWhileHTTPIsPending(t *testing.T) {
+	db := newNotifyTestDB(t)
+	initNotifyTestLog(t)
+
+	requestStarted := make(chan struct{}, 1)
+	releaseResponse := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestStarted <- struct{}{}
+		<-releaseResponse
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	order := newWaitingOrder(server.URL)
+	if err := db.Create(&order).Error; err != nil {
+		t.Fatalf("seed order: %v", err)
+	}
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- deliverBepusdtStatusUpdate(db, &http.Client{Timeout: 2 * time.Second}, "test-auth-token", order)
+	}()
+
+	select {
+	case <-requestStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("notification request never reached test server")
+	}
+
+	queryDone := make(chan error, 1)
+	go func() {
+		var count int64
+		queryDone <- db.Model(&model.Order{}).Where("status = ?", model.OrderStatusWaiting).Count(&count).Error
+	}()
+
+	select {
+	case err := <-queryDone:
+		if err != nil {
+			t.Fatalf("concurrent query failed: %v", err)
+		}
+	case <-time.After(300 * time.Millisecond):
+		close(releaseResponse)
+		<-errCh
+		t.Fatal("database query was blocked while notification HTTP request was in flight")
+	}
+
+	close(releaseResponse)
+	if err := <-errCh; err != nil {
+		t.Fatalf("deliver notification: %v", err)
+	}
+}


### PR DESCRIPTION
## 背景

在 SQLite 部署下，`notify.Bepusdt` 会在持有数据库事务时等待商户回调接口响应。  
当回调地址响应慢或超时时，会长时间占住数据库连接，进而拖慢甚至阻塞其他请求，表现为后台登录/API 长时间无响应。

## 变更

- 将 BEpusdt 状态回调逻辑从长事务中拆出
- 先读取订单状态，再发起外部 HTTP 回调，避免等待商户响应时持有数据库事务
- 保留现有的重复回调缓存逻辑
- 新增回归测试，模拟回调 HTTP 挂起时并发数据库查询仍能完成

## 验证

- `go test ./app/task/notify -run TestDeliverBepusdtStatusUpdateDoesNotHoldDBWhileHTTPIsPending -count=1`
- `go test ./... -count=1`

## 影响

- 修复慢回调导致的 SQLite 连接占用问题
- 降低后台登录/API 被外部回调拖慢或卡住的风险
