### PR TITLE
fix: Try to resolve the failed queue blocking web issue in Tron

### DIFF
--- a/app/task/tron.go
+++ b/app/task/tron.go
@@ -37,6 +37,9 @@ type tron struct {
 	blockScanQueue       *chanx.UnboundedChan[int]
 	conn                 map[string]*grpc.ClientConn
 	connMu               sync.RWMutex
+	retryMu              sync.Mutex
+	retryAttempts        map[int]int
+	retryScheduled       map[int]*time.Timer
 }
 
 var tr tron
@@ -54,6 +57,8 @@ func newTron() tron {
 		blockConfirmedOffset: 30,
 		blockScanQueue:       chanx.NewUnboundedChan[int](context.Background(), 30),
 		conn:                 make(map[string]*grpc.ClientConn),
+		retryAttempts:        make(map[int]int),
+		retryScheduled:       make(map[int]*time.Timer),
 	}
 }
 
@@ -138,7 +143,7 @@ func (t *tron) syncBlocksBackward(now int) {
 	}()
 }
 
-func (t *tron) blockDispatch(context.Context) {
+func (t *tron) blockDispatch(ctx context.Context) {
 	p, err := ants.NewPoolWithFunc(2, t.blockParse)
 	if err != nil {
 		log.Task.Warn("Error creating pool:", err)
@@ -148,11 +153,19 @@ func (t *tron) blockDispatch(context.Context) {
 
 	defer p.Release()
 
-	for n := range t.blockScanQueue.Out {
-		if err := p.Invoke(n); err != nil {
-			t.blockScanQueue.In <- n
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case n, ok := <-t.blockScanQueue.Out:
+			if !ok {
+				return
+			}
+			if err := p.Invoke(n); err != nil {
+				t.scheduleBlockRetry(n, 0)
 
-			log.Task.Warn("Tron Error invoking process block:", err)
+				log.Task.Warn("Tron Error invoking process block:", err)
+			}
 		}
 	}
 }
@@ -168,18 +181,19 @@ func (t *tron) blockParse(n any) {
 		return
 	}
 
-	conf.RecordSuccess(conf.Tron)
-
 	var ctx, cancel = context.WithTimeout(context.Background(), time.Second*5)
 	bok, err2 := api.NewWalletClient(conn).GetBlockByNum2(ctx, &api.NumberMessage{Num: int64(num)})
 	cancel()
 	if err2 != nil {
 		conf.RecordFailure(conf.Tron)
-		t.blockScanQueue.In <- int(num)
+		t.scheduleBlockRetry(num, 0)
 		log.Task.Warn("GetBlockByNum2 ", err2)
 
 		return
 	}
+
+	conf.RecordSuccess(conf.Tron)
+	t.resetBlockRetry(num)
 
 	var resources = make([]resource, 0)
 	var transfers = make([]transfer, 0)
@@ -493,6 +507,67 @@ func (t *tron) syncBreak() bool {
 	}
 
 	return true
+}
+
+func (t *tron) scheduleBlockRetry(num int, delay time.Duration) {
+	t.retryMu.Lock()
+	if _, ok := t.retryScheduled[num]; ok {
+		t.retryMu.Unlock()
+
+		return
+	}
+
+	attempt := t.retryAttempts[num] + 1
+	t.retryAttempts[num] = attempt
+
+	if delay <= 0 {
+		delay = tronRetryDelay(attempt)
+	}
+
+	var timer *time.Timer
+	timer = time.AfterFunc(delay, func() {
+		t.retryMu.Lock()
+		if t.retryScheduled[num] != timer {
+			t.retryMu.Unlock()
+
+			return
+		}
+		delete(t.retryScheduled, num)
+		t.retryMu.Unlock()
+
+		if t.blockScanQueue.Len() >= blockQueueLimit {
+			log.Task.Warn("Tron 重试延后，当前区块消费堆积数量：", t.blockScanQueue.Len())
+			t.scheduleBlockRetry(num, delay)
+
+			return
+		}
+
+		t.blockScanQueue.In <- num
+	})
+	t.retryScheduled[num] = timer
+	t.retryMu.Unlock()
+}
+
+func (t *tron) resetBlockRetry(num int) {
+	t.retryMu.Lock()
+	defer t.retryMu.Unlock()
+
+	delete(t.retryAttempts, num)
+	if timer, ok := t.retryScheduled[num]; ok {
+		timer.Stop()
+		delete(t.retryScheduled, num)
+	}
+}
+
+func tronRetryDelay(attempt int) time.Duration {
+	if attempt < 1 {
+		attempt = 1
+	}
+	if attempt > 5 {
+		attempt = 5
+	}
+
+	return time.Duration(1<<uint(attempt-1)) * 5 * time.Second
 }
 
 func (t *tron) client() (*grpc.ClientConn, error) {


### PR DESCRIPTION
Tron 扫块在 GetBlockByNum2 遇到 503 后会立刻把同一区块重新塞回队列，形成高频失败重试，然后会打满 CPU/日志/队列，导致 Web 无响应，重启进程后只要还有待支付订单或持续监控，又会继续进入这个循环。

修改内容：

- GetBlockByNum2 失败后不再立即重试，改为 5s、10s、20s、40s、80s 重试。
- 同一区块同一时间只允许一个重试定时器，成功后会取消/清理重试状态。
- 队列已堆积到 blockQueueLimit 时继续延后重试，避免把 Web 拖死。
- blockDispatch 现在会响应 ctx.Done()，进程关闭更干净。
- 当只有区块真正拉取成功后才记录成功。