### PR TITLE
update: minor adjustments to order confirmation

### DIFF
--- a/app/handler/admin/order.go
+++ b/app/handler/admin/order.go
@@ -201,10 +201,11 @@ func (Order) Paid(ctx *gin.Context) {
 		return
 	}
 
+	confirmedAt := time.Now()
 	var update = map[string]interface{}{
 		"ref_hash":     req.RefHash,
 		"status":       model.OrderStatusSuccess,
-		"confirmed_at": model.Datetime(time.Now()),
+		"confirmed_at": model.Datetime(confirmedAt),
 	}
 
 	err := model.Db.Model(&order).Updates(update).Error
@@ -213,6 +214,10 @@ func (Order) Paid(ctx *gin.Context) {
 
 		return
 	}
+
+	order.RefHash = req.RefHash
+	order.Status = model.OrderStatusSuccess
+	order.ConfirmedAt = &confirmedAt
 
 	go notify.Handle(order)
 

--- a/app/task/notify.go
+++ b/app/task/notify.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/v03413/bepusdt/app/log"
 	"github.com/v03413/bepusdt/app/model"
+	"github.com/v03413/bepusdt/app/notifier"
 	"github.com/v03413/bepusdt/app/task/notify"
 	"github.com/v03413/bepusdt/app/utils"
 )
@@ -36,4 +37,10 @@ func notifyRoll(context.Context) {
 	for _, o := range model.GetOrderByStatus(model.OrderStatusWaiting) {
 		notify.Bepusdt(o)
 	}
+}
+
+// notifyOrderSuccess 统一触发订单成功后的回调与订单通知。
+func notifyOrderSuccess(order model.Order) {
+	go notify.Handle(order)
+	go notifier.Success(order)
 }

--- a/app/task/transfer.go
+++ b/app/task/transfer.go
@@ -227,9 +227,7 @@ func tronResourceHandle(ctx context.Context) {
 
 func markFinalConfirmed(o model.Order) {
 	o.SetSuccess()
-
-	go notify.Handle(o)    // 订单回调
-	go notifier.Success(o) // 消息通知
+	notifyOrderSuccess(o)
 }
 
 func getAllWaitingOrders() map[string][]model.Order {


### PR DESCRIPTION
1. transfer.go markFinalConfirmed 方法的订单通知放在 notify.go 里更好一些。

2. admin/order.go 处理器补上字段，可以让后续 notify.Handle(order) 用到的是补单后最新的字段。之前是更新前查出来的 Go 结构体。Updates(update) 会写数据库，但不会自动把这些字段同步回当前这个 order 变量。