### PR TITLE
perf: add order notify retry index

### DIFF
--- a/app/model/order.go
+++ b/app/model/order.go
@@ -65,13 +65,13 @@ type Order struct {
 	Address       string     `gorm:"column:address;type:varchar(128);index;not null;comment:收款地址" json:"address"`
 	FromAddress   string     `gorm:"column:from_address;type:varchar(128);not null;default:'';comment:支付地址" json:"from_address"`
 	AddressLocked bool       `gorm:"column:address_locked;not null;default:false;comment:地址锁定 1:独占 0:共享" json:"address_locked"`
-	Status        int        `gorm:"column:status;not null;default:1;index;comment:交易状态" json:"status"`
+	Status        int        `gorm:"column:status;not null;default:1;index;index:idx_order_notify_retry,priority:1;comment:交易状态" json:"status"`
 	Name          string     `gorm:"column:name;type:varchar(64);not null;default:'';comment:商品名称" json:"name"`
 	ApiType       string     `gorm:"column:api_type;type:varchar(20);not null;default:'epusdt';comment:API类型" json:"api_type"`
 	ReturnUrl     string     `gorm:"column:return_url;type:varchar(255);not null;default:'';comment:同步地址" json:"return_url"`
 	NotifyUrl     string     `gorm:"column:notify_url;type:varchar(255);not null;default:'';comment:异步地址" json:"notify_url"`
-	NotifyNum     int        `gorm:"column:notify_num;not null;default:0;comment:回调次数" json:"notify_num"`
-	NotifyState   int        `gorm:"column:notify_state;not null;default:0;comment:回调状态 1：成功 0：失败" json:"notify_state"`
+	NotifyNum     int        `gorm:"column:notify_num;not null;default:0;index:idx_order_notify_retry,priority:3;comment:回调次数" json:"notify_num"`
+	NotifyState   int        `gorm:"column:notify_state;not null;default:0;index:idx_order_notify_retry,priority:2;comment:回调状态 1：成功 0：失败" json:"notify_state"`
 	RefHash       string     `gorm:"column:ref_hash;type:varchar(128);not null;default:'';index;comment:交易哈希" json:"ref_hash"`
 	RefBlockNum   int        `gorm:"column:ref_block_num;not null;default:0;comment:区块索引" json:"ref_block_num"`
 	ExpiredAt     time.Time  `gorm:"column:expired_at;not null;comment:失效时间" json:"expired_at"`
@@ -180,9 +180,14 @@ func GetOrderByStatus(Status int) []Order {
 
 func GetNotifyFailedTradeOrders() ([]Order, error) {
 	var orders []Order
+	maxRetry := cast.ToInt(GetC(NotifyMaxRetry))
+	if maxRetry <= 0 {
+		maxRetry = cast.ToInt(defaultConf[NotifyMaxRetry])
+	}
+
 	res := Db.Where("status = ?", OrderStatusSuccess).
-		Where("notify_num <= ?", GetC(NotifyMaxRetry)).
-		Where("notify_state = ?", OrderNotifyStateFail).Find(&orders)
+		Where("notify_state = ?", OrderNotifyStateFail).
+		Where("notify_num <= ?", maxRetry).Find(&orders)
 
 	return orders, res.Error
 }


### PR DESCRIPTION
2026/05/02 15:54:16 github.com/v03413/bepusdt/app/model/order.go:202 SLOW SQL >= 200ms
[238.032ms] [rows:0] SELECT * FROM `bep_order` WHERE status = 2 AND notify_num <= "10" AND notify_state = 0

notify_num 是字符串比较而不是 int，先转换为 int 再比较；
加一个索引： idx_order_notify_retry(status, notify_state, notify_num) 这样更好些，然后为了匹配 index 顺序，改了一下查询顺序。