### PR TITLE
feat: dashboard: Enhanced dashboard displays more statistics

### DIFF
--- a/app/handler/admin/dashboard.go
+++ b/app/handler/admin/dashboard.go
@@ -1,19 +1,37 @@
 package admin
 
 import (
+	"errors"
+	"fmt"
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/shopspring/decimal"
 	"github.com/spf13/cast"
 	"github.com/v03413/bepusdt/app/handler/base"
 	"github.com/v03413/bepusdt/app/model"
+	"github.com/v03413/go-cache"
 )
 
 type Dashboard struct {
 }
 
 type homeReq struct {
-	Fiat string `json:"fiat" binding:"required"`
+	Fiat  string `json:"fiat" binding:"required"`
+	Range string `json:"range"`
+	TZ    string `json:"tz"`
+	From  string `json:"from"`
+	To    string `json:"to"`
+	Force bool   `json:"force"`
+}
+
+type dashboardPoint struct {
+	Date          string `json:"date"`
+	OrdersTotal   int64  `json:"orders_total"`
+	OrdersPaid    int64  `json:"orders_paid"`
+	OrdersSuccess int64  `json:"orders_success"`
+	OrdersFailed  int64  `json:"orders_failed"`
+	GMVPaid       string `json:"gmv_paid"`
 }
 
 func (Dashboard) Home(ctx *gin.Context) {
@@ -24,13 +42,33 @@ func (Dashboard) Home(ctx *gin.Context) {
 		return
 	}
 
-	var rows = make([]model.Order, 0)
-	model.Db.Where("fiat = ? and status = ?", req.Fiat, model.OrderStatusSuccess).Find(&rows)
+	rangeKey, from, to, loc, err := resolveDashboardRange(req)
+	if err != nil {
+		base.BadRequest(ctx, err.Error())
 
-	var today = time.Now().Format("2006-01-02")
-	var totalMoney, todayMoney float64
-	var totalCount, todayCount int64
-	var monthly = make(map[string]float64)
+		return
+	}
+
+	cacheKey := dashboardCacheKey(req.Fiat, rangeKey, loc.String(), from, to)
+	if !req.Force {
+		if data, ok := cache.Get(cacheKey); ok {
+			base.Ok(ctx, data)
+
+			return
+		}
+	}
+
+	data := buildDashboardHome(req, rangeKey, from, to, loc)
+	cache.Set(cacheKey, data, dashboardCacheTTL(rangeKey, to, loc))
+	base.Ok(ctx, data)
+}
+
+func buildDashboardHome(req homeReq, rangeKey string, from, to time.Time, loc *time.Location) gin.H {
+	var rows = make([]model.Order, 0)
+	model.Db.Where("fiat = ? and created_at >= ? and created_at <= ?", req.Fiat, from, to).Find(&rows)
+
+	var totalCount, pendingCount, confirmingCount, successCount, expiredCount, failedCount, notifyFailedCount int64
+	gmvPaid := decimal.Zero
 	var tokenMap = map[model.Crypto]float64{
 		model.USDT: 0,
 		model.USDC: 0,
@@ -38,38 +76,198 @@ func (Dashboard) Home(ctx *gin.Context) {
 		model.BNB:  0,
 		model.ETH:  0,
 	}
+	points := make([]dashboardPoint, 0)
+	pointMap := make(map[string]int)
+	for day := dayStart(from, loc); !day.After(dayStart(to, loc)); day = day.AddDate(0, 0, 1) {
+		date := day.Format("2006-01-02")
+		point := dashboardPoint{
+			Date:    date,
+			GMVPaid: "0.00",
+		}
+		points = append(points, point)
+		pointMap[date] = len(points) - 1
+	}
 
 	for _, itm := range rows {
-		money := cast.ToFloat64(itm.Money)
-
-		totalMoney += money
 		totalCount++
-		if itm.CreatedAt.Format("2006-01-02") == today {
-			todayMoney += money
-			todayCount++
+		createdAt := time.Now().In(loc)
+		if itm.CreatedAt != nil {
+			createdAt = time.Time(*itm.CreatedAt).In(loc)
 		}
+		date := createdAt.Format("2006-01-02")
+		pointIndex, ok := pointMap[date]
+		if !ok {
+			continue
+		}
+		point := &points[pointIndex]
 
-		if crypto, err := model.GetCrypto(itm.TradeType); err == nil {
+		point.OrdersTotal++
+
+		switch itm.Status {
+		case model.OrderStatusWaiting:
+			pendingCount++
+		case model.OrderStatusConfirming:
+			confirmingCount++
+		case model.OrderStatusExpired:
+			expiredCount++
+		case model.OrderStatusSuccess:
+			successCount++
+			point.OrdersSuccess++
+			point.OrdersPaid++
+
+			money, _ := decimal.NewFromString(itm.Money)
+			gmvPaid = gmvPaid.Add(money)
+			pointMoney, _ := decimal.NewFromString(point.GMVPaid)
+			point.GMVPaid = pointMoney.Add(money).Round(2).StringFixed(2)
+
+			crypto := itm.Crypto
+			if crypto == "" {
+				if tradeCrypto, err := model.GetCrypto(itm.TradeType); err == nil {
+					crypto = tradeCrypto
+				}
+			}
 			if _, ok := tokenMap[crypto]; !ok {
 				tokenMap[crypto] = 0
 			}
+			tokenAmount := cast.ToFloat64(itm.Amount)
+			if tokenAmount == 0 {
+				tokenAmount = cast.ToFloat64(itm.Money)
+			}
+			tokenMap[crypto] += tokenAmount
 
-			tokenMap[crypto] += money
+			if itm.NotifyState == model.OrderNotifyStateFail {
+				notifyFailedCount++
+			}
+		case model.OrderStatusFailed:
+			failedCount++
+			point.OrdersFailed++
 		}
-
-		var month = itm.CreatedAt.Time().Format("2006/01")
-		if _, ok := monthly[month]; !ok {
-			monthly[month] = 0
-		}
-		monthly[month] += money
 	}
 
-	base.Ok(ctx, gin.H{
-		"total_money": totalMoney,
-		"total_count": totalCount,
-		"today_money": todayMoney,
-		"today_count": todayCount,
-		"token_map":   tokenMap,
-		"monthly":     monthly,
-	})
+	successRate := "0.00"
+	finishedCount := successCount + expiredCount + failedCount
+	if finishedCount > 0 {
+		rate := decimal.NewFromInt(successCount).Div(decimal.NewFromInt(finishedCount)).Mul(decimal.NewFromInt(100))
+		successRate = rate.Round(2).StringFixed(2)
+	}
+
+	return gin.H{
+		"range":    rangeKey,
+		"from":     from.In(loc).Format(time.RFC3339),
+		"to":       to.In(loc).Format(time.RFC3339),
+		"timezone": loc.String(),
+		"currency": req.Fiat,
+		"kpi": gin.H{
+			"orders_total":       totalCount,
+			"orders_pending":     pendingCount,
+			"orders_confirming":  confirmingCount,
+			"gmv_paid":           gmvPaid.Round(2).StringFixed(2),
+			"orders_success":     successCount,
+			"orders_failed":      failedCount,
+			"notify_failed":      notifyFailedCount,
+			"order_success_rate": successRate,
+		},
+		"token_map": tokenMap,
+		"points":    points,
+	}
+}
+
+func dashboardCacheKey(fiat, rangeKey, timezone string, from, to time.Time) string {
+	return fmt.Sprintf("dashboard:home:v1:%s:%s:%s:%d:%d", fiat, rangeKey, timezone, from.Unix(), to.Unix())
+}
+
+func dashboardCacheTTL(rangeKey string, to time.Time, loc *time.Location) time.Duration {
+	switch rangeKey {
+	case "today":
+		return 10 * time.Second
+	case "30d":
+		return time.Minute
+	case "custom":
+		if to.Before(dayStart(time.Now().In(loc), loc)) {
+			return 5 * time.Minute
+		}
+
+		return 30 * time.Second
+	default:
+		return 30 * time.Second
+	}
+}
+
+func resolveDashboardRange(req homeReq) (string, time.Time, time.Time, *time.Location, error) {
+	loc := time.Local
+	if req.TZ != "" {
+		if loadedLoc, err := time.LoadLocation(req.TZ); err == nil {
+			loc = loadedLoc
+		}
+	}
+
+	rangeKey := req.Range
+	if rangeKey == "" {
+		rangeKey = "7d"
+	}
+
+	now := time.Now().In(loc)
+	switch rangeKey {
+	case "today":
+		start := dayStart(now, loc)
+		return rangeKey, start, dayEnd(start), loc, nil
+	case "30d":
+		yesterday := dayStart(now, loc).AddDate(0, 0, -1)
+		start := yesterday.AddDate(0, 0, -29)
+		return rangeKey, start, dayEnd(yesterday), loc, nil
+	case "custom":
+		from, err := parseDashboardDate(req.From, loc, true)
+		if err != nil {
+			return "", time.Time{}, time.Time{}, nil, err
+		}
+		to, err := parseDashboardDate(req.To, loc, false)
+		if err != nil {
+			return "", time.Time{}, time.Time{}, nil, err
+		}
+		if to.Before(from) {
+			return "", time.Time{}, time.Time{}, nil, errors.New("自定义统计周期结束时间不能早于开始时间")
+		}
+
+		return rangeKey, from, to, loc, nil
+	case "7d":
+		fallthrough
+	default:
+		yesterday := dayStart(now, loc).AddDate(0, 0, -1)
+		start := yesterday.AddDate(0, 0, -6)
+		return "7d", start, dayEnd(yesterday), loc, nil
+	}
+}
+
+func parseDashboardDate(value string, loc *time.Location, start bool) (time.Time, error) {
+	if value == "" {
+		return time.Time{}, errors.New("请选择自定义统计周期")
+	}
+
+	layouts := []string{time.RFC3339, "2006-01-02 15:04:05", "2006-01-02"}
+	for _, layout := range layouts {
+		t, err := time.ParseInLocation(layout, value, loc)
+		if err != nil {
+			continue
+		}
+		if layout == "2006-01-02" {
+			if start {
+				return dayStart(t, loc), nil
+			}
+			return dayEnd(t), nil
+		}
+
+		return t.In(loc), nil
+	}
+
+	return time.Time{}, errors.New("自定义统计周期格式错误")
+}
+
+func dayStart(t time.Time, loc *time.Location) time.Time {
+	local := t.In(loc)
+	return time.Date(local.Year(), local.Month(), local.Day(), 0, 0, 0, 0, loc)
+}
+
+func dayEnd(t time.Time) time.Time {
+	start := time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, t.Location())
+	return start.Add(24*time.Hour - time.Nanosecond)
 }

--- a/web/src/style/media/layout.scss
+++ b/web/src/style/media/layout.scss
@@ -8,7 +8,7 @@
     height: 400px;
     padding-bottom: $padding;
   }
-  .monthly-analysis {
+  .daily-analysis {
     width: 100%;
     height: 400px;
     padding-bottom: $padding;
@@ -22,7 +22,7 @@
     height: 400px;
     padding-bottom: $padding;
   }
-  .monthly-analysis {
+  .daily-analysis {
     width: 100%;
     height: 400px;
     padding-bottom: $padding;
@@ -36,7 +36,7 @@
     height: 400px;
     padding-bottom: $padding;
   }
-  .monthly-analysis {
+  .daily-analysis {
     width: 600px;
     height: 400px;
     padding-bottom: $padding;

--- a/web/src/views/home/components/analysis-chart.vue
+++ b/web/src/views/home/components/analysis-chart.vue
@@ -1,5 +1,7 @@
 <template>
-  <div style="height: 100%" ref="monthlyAnalysis"></div>
+  <div class="analysis-chart" :class="{ empty: isEmpty }" ref="dailyAnalysis">
+    <a-empty v-if="isEmpty" description="暂无交易数据" />
+  </div>
 </template>
 
 <script setup lang="ts">
@@ -9,12 +11,32 @@ const props = defineProps<{
   homeData: any;
 }>();
 
-const monthlyAnalysis = ref();
+const dailyAnalysis = ref();
+const isEmpty = ref(false);
 let vchart: any = null;
+let resizeObserver: ResizeObserver | null = null;
+let initTimer: ReturnType<typeof setTimeout> | null = null;
 
-const init = () => {
+const releaseChart = () => {
+  if (vchart) {
+    vchart.release();
+    vchart = null;
+  }
+};
+
+const scheduleInit = (delay = 0) => {
+  if (initTimer) {
+    clearTimeout(initTimer);
+  }
+  initTimer = setTimeout(() => {
+    initTimer = null;
+    init();
+  }, delay);
+};
+
+const init = async (retryCount = 0) => {
   try {
-    if (!props.homeData?.token_map || !monthlyAnalysis.value) return;
+    if (!props.homeData?.token_map || !dailyAnalysis.value) return;
 
     const tokenMap = props.homeData.token_map;
     if (typeof tokenMap !== "object" || tokenMap === null) return;
@@ -24,7 +46,11 @@ const init = () => {
       return sum + (isNaN(numValue) ? 0 : numValue);
     }, 0);
 
-    if (totalAmount === 0) return;
+    if (totalAmount === 0) {
+      releaseChart();
+      isEmpty.value = true;
+      return;
+    }
 
     const chartData = Object.entries(tokenMap)
       .map(([token, amount]) => {
@@ -39,22 +65,35 @@ const init = () => {
       })
       .filter(item => item !== null);
 
-    if (chartData.length === 0) return;
-
-    if (vchart) {
-      vchart.release();
-      vchart = null;
+    if (chartData.length === 0) {
+      releaseChart();
+      isEmpty.value = true;
+      return;
     }
+
+    isEmpty.value = false;
+    await nextTick();
+
+    const containerWidth = dailyAnalysis.value?.clientWidth || 0;
+    const containerHeight = dailyAnalysis.value?.clientHeight || 0;
+    if ((!containerWidth || !containerHeight) && retryCount < 8) {
+      setTimeout(() => init(retryCount + 1), 100);
+      return;
+    }
+
+    releaseChart();
 
     const colorMap = {
       USDT: "#1E90FF",
       USDC: "#32CD32",
-      TRX: "#FF4500"
+      TRX: "#FF4500",
+      BNB: "#F5A623",
+      ETH: "#722ED1"
     };
 
     const spec = {
       type: "pie",
-      data: [{ id: "monthlyAnalysisData", values: chartData }],
+      data: [{ id: "dailyAnalysisData", values: chartData }],
       outerRadius: 0.8,
       innerRadius: 0.5,
       padAngle: 0.6,
@@ -85,20 +124,17 @@ const init = () => {
         }
       },
       animation: false,
-      width: monthlyAnalysis.value?.clientWidth || 400,
-      height: monthlyAnalysis.value?.clientHeight || 300
+      width: containerWidth || 400,
+      height: containerHeight || 300
     };
 
-    if (monthlyAnalysis.value?.isConnected) {
-      vchart = new VChart(spec as any, { dom: monthlyAnalysis.value });
+    if (dailyAnalysis.value?.isConnected) {
+      vchart = new VChart(spec as any, { dom: dailyAnalysis.value });
       vchart.renderSync();
     }
   } catch (error) {
     console.error("分析图表初始化错误:", error);
-    if (vchart) {
-      vchart.release();
-      vchart = null;
-    }
+    releaseChart();
   }
 };
 
@@ -106,7 +142,7 @@ watch(
   () => props.homeData,
   newData => {
     try {
-      if (newData?.token_map) init();
+      if (newData?.token_map) scheduleInit(120);
     } catch (error) {
       console.error("分析图表更新失败:", error);
     }
@@ -116,7 +152,11 @@ watch(
 
 onMounted(() => {
   try {
-    if (props.homeData?.token_map) init();
+    if (typeof ResizeObserver !== "undefined" && dailyAnalysis.value) {
+      resizeObserver = new ResizeObserver(() => scheduleInit(120));
+      resizeObserver.observe(dailyAnalysis.value);
+    }
+    if (props.homeData?.token_map) scheduleInit(160);
   } catch (error) {
     console.error("分析图表初始化失败:", error);
   }
@@ -124,12 +164,29 @@ onMounted(() => {
 
 onUnmounted(() => {
   try {
-    vchart?.release();
-    vchart = null;
+    if (initTimer) {
+      clearTimeout(initTimer);
+      initTimer = null;
+    }
+    resizeObserver?.disconnect();
+    resizeObserver = null;
+    releaseChart();
   } catch (error) {
     console.error("清理图表失败:", error);
   }
 });
 </script>
 
-<style lang="scss" scoped></style>
+<style lang="scss" scoped>
+.analysis-chart {
+  width: 100%;
+  height: 100%;
+  min-height: 300px;
+
+  &.empty {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+}
+</style>

--- a/web/src/views/home/components/data-box.vue
+++ b/web/src/views/home/components/data-box.vue
@@ -3,17 +3,21 @@
     <div class="sell-histogram">
       <div>
         <span class="data-title">收款趋势</span>
-        <span class="data-subtext">单位：元</span>
+        <span class="data-subtext">单位: 天</span>
       </div>
 
-      <HistogramChart :home-data="props.homeData" :key="chartKey" />
+      <div class="chart-body">
+        <HistogramChart :home-data="props.homeData" />
+      </div>
     </div>
-    <div class="monthly-analysis">
+    <div class="daily-analysis">
       <div>
         <span class="data-title">交易占比</span>
       </div>
 
-      <AnalysisChart :home-data="props.homeData" :key="chartKey" />
+      <div class="chart-body">
+        <AnalysisChart :home-data="props.homeData" />
+      </div>
     </div>
   </div>
 </template>
@@ -25,18 +29,6 @@ import AnalysisChart from "@/views/home/components/analysis-chart.vue";
 const props = defineProps<{
   homeData: any;
 }>();
-
-const chartKey = ref(0);
-
-watch(
-  () => props.homeData,
-  newData => {
-    if (newData) {
-      chartKey.value++;
-    }
-  },
-  { deep: true }
-);
 </script>
 
 <style lang="scss" scoped>
@@ -45,6 +37,30 @@ watch(
   flex-wrap: wrap;
   justify-content: space-between;
   margin-top: calc($padding * 2);
+
+  .sell-histogram,
+  .daily-analysis {
+    display: flex;
+    flex-direction: column;
+    height: 400px;
+    padding-bottom: $padding;
+    min-width: 0;
+  }
+
+  .sell-histogram {
+    width: 100%;
+  }
+
+  .daily-analysis {
+    width: 100%;
+  }
+
+  .chart-body {
+    flex: 1;
+    min-height: 0;
+    min-width: 0;
+  }
+
   .data-title {
     font-size: $font-size-body-3;
     color: $color-text-1;
@@ -53,6 +69,19 @@ watch(
     margin-left: $margin-text;
     font-size: $font-size-body-2;
     color: $color-text-2;
+  }
+}
+
+@media screen and (min-width: $xxl) {
+  .data-box {
+    .sell-histogram {
+      width: calc(100% - 600px - $padding);
+    }
+
+    .daily-analysis {
+      width: 600px;
+      margin-left: $padding;
+    }
   }
 }
 </style>

--- a/web/src/views/home/components/finance.vue
+++ b/web/src/views/home/components/finance.vue
@@ -4,26 +4,18 @@
       <div>数据汇总</div>
     </div>
     <a-divider :margin="16" />
-    <a-grid class="finance-card" :cols="{ xs: 1, sm: 2, lg: 4, xl: 4 }" :col-gap="16" :row-gap="28">
+    <a-grid class="finance-card" :cols="{ xs: 1, sm: 2, lg: 3, xl: 5 }" :col-gap="16" :row-gap="20">
       <a-grid-item v-for="(item, index) in financeData" :key="index">
         <a-card hoverable class="finance-a-card" :class="'animated-fade-up-' + index">
           <div class="finance-nav">
             <div class="tag-dot" :style="{ border: `3px solid ${item.color}` }"></div>
             <span class="finance-nav-title">{{ item.title }}</span>
           </div>
-          <a-statistic
-            :value-style="{
-              fontSize: '13px',
-              marginLeft: '16px',
-              marginTop: '12px'
-            }"
-            :value="item.value"
-            :value-from="0"
-            :start="true"
-            animation
-            :show-group-separator="false"
-            :precision="item.precision"
-          />
+          <div class="finance-value">{{ item.value }}</div>
+          <div class="finance-sub">
+            <span>{{ item.subLabel }}</span>
+            <span>{{ item.subValue }}</span>
+          </div>
         </a-card>
       </a-grid-item>
     </a-grid>
@@ -35,47 +27,65 @@ const props = defineProps<{
   homeData: any;
 }>();
 
-const financeData = ref([
-  {
-    id: 1,
-    title: "累计订单",
-    value: props.homeData?.total_count || 0,
-    color: "#165DFF",
-    precision: 0
-  },
-  {
-    id: 2,
-    title: "今日订单",
-    value: props.homeData?.today_count || 0,
-    color: "#6c73ff",
-    precision: 0
-  },
-  {
-    id: 3,
-    title: "今日收款",
-    value: props.homeData?.today_money || 0,
-    color: "#39cbab",
-    precision: 2
-  },
+const formatAmount = (value: any) => Number(value || 0).toFixed(2);
 
-  {
-    id: 4,
-    title: "总计收款",
-    value: props.homeData?.total_money || 0,
-    color: "#ff8625",
-    precision: 2
-  }
-]);
+const formatPeriod = (from?: string, to?: string) => {
+  if (!from || !to) return "--";
+  return `${from.slice(5, 10).replace("-", "/")} - ${to.slice(5, 10).replace("-", "/")}`;
+};
+
+const buildFinanceData = (data: any) => {
+  const kpi = data?.kpi || {};
+  return [
+    {
+      id: 1,
+      title: "订单总数",
+      value: kpi.orders_total || 0,
+      subLabel: "已支付订单:",
+      subValue: kpi.orders_success || 0,
+      color: "#165DFF"
+    },
+    {
+      id: 2,
+      title: "收款金额",
+      value: formatAmount(kpi.gmv_paid),
+      subLabel: "支付成功率:",
+      subValue: `${formatAmount(kpi.order_success_rate)}%`,
+      color: "#14A058"
+    },
+    {
+      id: 3,
+      title: "待付订单",
+      value: kpi.orders_pending || 0,
+      subLabel: "确认中订单:",
+      subValue: kpi.orders_confirming || 0,
+      color: "#F5A623"
+    },
+    {
+      id: 4,
+      title: "失败订单",
+      value: kpi.orders_failed || 0,
+      subLabel: "通知失败:",
+      subValue: kpi.notify_failed || 0,
+      color: "#E33E38"
+    },
+    {
+      id: 5,
+      title: "统计周期",
+      value: formatPeriod(data?.from, data?.to),
+      subLabel: "",
+      subValue: data?.timezone || "--",
+      color: "#722ED1"
+    }
+  ];
+};
+
+const financeData = ref(buildFinanceData(props.homeData));
 
 watch(
   () => props.homeData,
   newData => {
-    if (newData) {
-      financeData.value[0].value = newData.total_count || 0;
-      financeData.value[1].value = newData.today_count || 0;
-      financeData.value[2].value = newData.today_money || 0;
-      financeData.value[3].value = newData.total_money || 0;
-    }
+    financeData.value = buildFinanceData(newData);
   },
   { immediate: true }
 );
@@ -107,6 +117,27 @@ watch(
   justify-content: space-between;
   font-size: $font-size-body-3;
   color: $color-text-1;
+}
+.finance-a-card {
+  min-height: 126px;
+}
+.finance-value {
+  margin: 14px 0 0 16px;
+  color: $color-text-1;
+  font-size: 24px;
+  line-height: 32px;
+  font-weight: 600;
+  word-break: break-word;
+}
+.finance-sub {
+  display: flex;
+  gap: 6px;
+  align-items: center;
+  margin: 8px 0 0 16px;
+  color: $color-text-2;
+  font-size: 13px;
+  line-height: 18px;
+  white-space: nowrap;
 }
 .margin-left-text {
   margin-left: $margin-text;

--- a/web/src/views/home/components/histogram-chart.vue
+++ b/web/src/views/home/components/histogram-chart.vue
@@ -1,5 +1,8 @@
 <template>
-  <div style="height: 100%" ref="sellHistogram"></div>
+  <div class="histogram-scroll" :class="{ empty: isEmpty, scrollable: isScrollable }" ref="histogramScroll">
+    <a-empty v-if="isEmpty" description="暂无订单数据" />
+    <div v-show="!isEmpty" class="histogram-canvas" ref="sellHistogram" :style="{ width: `${chartWidth}px` }"></div>
+  </div>
 </template>
 
 <script setup lang="ts">
@@ -10,37 +13,138 @@ const props = defineProps<{
 }>();
 
 const sellHistogram = ref();
+const histogramScroll = ref();
+const chartWidth = ref(0);
+const isEmpty = ref(false);
+const isScrollable = ref(false);
 let vchart: any = null;
+let resizeObserver: ResizeObserver | null = null;
+let initTimer: ReturnType<typeof setTimeout> | null = null;
 
-const init = () => {
+const releaseChart = () => {
+  if (vchart) {
+    vchart.release();
+    vchart = null;
+  }
+};
+
+const scheduleInit = (delay = 0) => {
+  if (initTimer) {
+    clearTimeout(initTimer);
+  }
+  initTimer = setTimeout(() => {
+    initTimer = null;
+    init();
+  }, delay);
+};
+
+const getCssVarRgb = (name: string, fallback: string) => {
+  const bodyValue = getComputedStyle(document.body).getPropertyValue(name).trim();
+  const value = bodyValue || getComputedStyle(document.documentElement).getPropertyValue(name).trim();
+  return value ? `rgb(${value})` : fallback;
+};
+
+const getThemeColors = () => {
+  return [getCssVarRgb("--primary-6", "#165dff"), getCssVarRgb("--success-6", "#00b42a")];
+};
+
+const init = async (retryCount = 0) => {
   try {
-    if (!props.homeData?.monthly || !sellHistogram.value) return;
+    if (!props.homeData?.points || !sellHistogram.value || !histogramScroll.value) return;
 
-    const monthlyData = props.homeData.monthly;
-    if (typeof monthlyData !== "object" || monthlyData === null) return;
+    const points = props.homeData.points;
+    if (!Array.isArray(points)) return;
 
-    const chartData = Object.entries(monthlyData).map(([month, sales]) => ({
-      month,
-      sales: Number(Number(sales).toFixed(2)) || 0
-    }));
+    const gmvPaidByDate: Record<string, string> = {};
+    const chartData = points.flatMap(point => {
+      const date = String(point.date || "")
+        .slice(5)
+        .replace("-", "/");
+      gmvPaidByDate[date] = Number(point.gmv_paid || 0).toFixed(2);
+      return [
+        {
+          date,
+          type: "订单总数",
+          value: Number(point.orders_total || 0)
+        },
+        {
+          date,
+          type: "已支付订单",
+          value: Number(point.orders_paid ?? point.orders_success ?? 0)
+        }
+      ];
+    });
 
     if (chartData.length === 0) return;
 
-    if (vchart) {
-      vchart.release();
-      vchart = null;
+    const hasOrderData = chartData.some(item => item.value > 0);
+    if (!hasOrderData) {
+      releaseChart();
+      isEmpty.value = true;
+      isScrollable.value = false;
+      return;
     }
+
+    isEmpty.value = false;
+    await nextTick();
+
+    const containerWidth = histogramScroll.value?.clientWidth || 0;
+    const containerHeight = sellHistogram.value?.clientHeight || histogramScroll.value?.clientHeight || 0;
+    if ((!containerWidth || !containerHeight) && retryCount < 8) {
+      setTimeout(() => init(retryCount + 1), 100);
+      return;
+    }
+
+    const renderWidth = containerWidth || 400;
+    const renderHeight = containerHeight || 300;
+    isScrollable.value = points.length > 7;
+    chartWidth.value = isScrollable.value ? Math.max(renderWidth, points.length * 44) : renderWidth;
+    await nextTick();
+
+    releaseChart();
 
     const spec = {
       type: "bar",
       data: [{ id: "sellHistogramData", values: chartData }],
-      xField: "month",
-      yField: "sales",
-      barWidth: 10,
-      barGapInGroup: 0,
+      xField: ["date", "type"],
+      yField: "value",
+      seriesField: "type",
+      barWidth: 9,
+      barGapInGroup: 2,
+      legends: { visible: true, orient: "top", position: "middle" },
+      color: {
+        type: "ordinal",
+        domain: ["订单总数", "已支付订单"],
+        range: getThemeColors()
+      },
+      axes: [
+        {
+          orient: "bottom",
+          label: {
+            visible: true,
+            formatMethod: (value: string) => (gmvPaidByDate[value] ? [value, gmvPaidByDate[value]] : value),
+            style: {
+              fontSize: 10,
+              lineHeight: 13
+            }
+          },
+          showAllGroupLayers: false
+        },
+        { orient: "left", label: { visible: true }, min: 0 }
+      ],
+      tooltip: {
+        mark: {
+          content: [
+            {
+              key: (datum: any) => datum["type"],
+              value: (datum: any) => datum["value"]
+            }
+          ]
+        }
+      },
       animation: false,
-      width: sellHistogram.value?.clientWidth || 400,
-      height: sellHistogram.value?.clientHeight || 300
+      width: chartWidth.value || renderWidth,
+      height: renderHeight
     };
 
     if (sellHistogram.value?.isConnected) {
@@ -49,10 +153,7 @@ const init = () => {
     }
   } catch (error) {
     console.error("图表初始化错误:", error);
-    if (vchart) {
-      vchart.release();
-      vchart = null;
-    }
+    releaseChart();
   }
 };
 
@@ -60,7 +161,7 @@ watch(
   () => props.homeData,
   newData => {
     try {
-      if (newData?.monthly) init();
+      if (newData?.points) scheduleInit(120);
     } catch (error) {
       console.error("图表更新失败:", error);
     }
@@ -70,7 +171,11 @@ watch(
 
 onMounted(() => {
   try {
-    if (props.homeData?.monthly) init();
+    if (typeof ResizeObserver !== "undefined" && histogramScroll.value) {
+      resizeObserver = new ResizeObserver(() => scheduleInit(120));
+      resizeObserver.observe(histogramScroll.value);
+    }
+    if (props.homeData?.points) scheduleInit(160);
   } catch (error) {
     console.error("图表初始化失败:", error);
   }
@@ -78,12 +183,40 @@ onMounted(() => {
 
 onUnmounted(() => {
   try {
-    vchart?.release();
-    vchart = null;
+    if (initTimer) {
+      clearTimeout(initTimer);
+      initTimer = null;
+    }
+    resizeObserver?.disconnect();
+    resizeObserver = null;
+    releaseChart();
   } catch (error) {
     console.error("清理图表失败:", error);
   }
 });
 </script>
 
-<style lang="scss" scoped></style>
+<style lang="scss" scoped>
+.histogram-scroll {
+  width: 100%;
+  height: 100%;
+  overflow-x: hidden;
+  overflow-y: hidden;
+
+  &.scrollable {
+    overflow-x: auto;
+  }
+
+  &.empty {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+}
+
+.histogram-canvas {
+  height: 100%;
+  min-width: 100%;
+  min-height: 300px;
+}
+</style>

--- a/web/src/views/home/home.vue
+++ b/web/src/views/home/home.vue
@@ -18,6 +18,25 @@
             </div>
           </div>
         </div>
+
+        <div class="range-actions">
+          <a-range-picker
+            v-if="range === 'custom'"
+            v-model="customDates"
+            format="YYYY-MM-DD"
+            style="width: 240px"
+            @change="handleCustomDateChange"
+          />
+          <a-select v-model="range" style="width: 132px" @change="handleRangeChange">
+            <a-option v-for="item in rangeOptions" :key="item.value" :value="item.value">
+              {{ item.label }}
+            </a-option>
+          </a-select>
+          <a-button type="primary" :loading="loading" @click="forceRefresh">
+            <template #icon><icon-refresh /></template>
+            强制刷新
+          </a-button>
+        </div>
       </div>
 
       <!-- 财务指标 -->
@@ -34,7 +53,12 @@ import DataBox from "@/views/home/components/data-box.vue";
 import { getDashboardHomeAPI } from "@/api/modules/home/index";
 
 const fiat = ref("CNY");
+const range = ref("7d");
+const customDates = ref<any[]>([]);
 const home = ref<any>(null);
+const loading = ref(false);
+const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone || "Asia/Shanghai";
+let dashboardRetryTimer: ReturnType<typeof setTimeout> | null = null;
 
 const fiatOptions = ref([
   { value: "CNY", label: "人民币", symbol: "¥" },
@@ -44,9 +68,56 @@ const fiatOptions = ref([
   { value: "JPY", label: "日元", symbol: "¥" }
 ]);
 
-const getDashboardHome = async () => {
-  const data = await getDashboardHomeAPI({ fiat: fiat.value });
-  home.value = data.data;
+const rangeOptions = [
+  { value: "today", label: "今天" },
+  { value: "7d", label: "最近 7 天" },
+  { value: "30d", label: "最近 30 天" },
+  { value: "custom", label: "自定义" }
+];
+
+const clearDashboardRetry = () => {
+  if (dashboardRetryTimer) {
+    clearTimeout(dashboardRetryTimer);
+    dashboardRetryTimer = null;
+  }
+};
+
+const getDashboardHome = async (force = false, retryCount = 0) => {
+  if (range.value === "custom" && (!Array.isArray(customDates.value) || customDates.value.length !== 2)) return;
+
+  if (retryCount === 0) {
+    clearDashboardRetry();
+  }
+
+  loading.value = true;
+  try {
+    const params: any = {
+      range: range.value,
+      tz: timezone,
+      fiat: fiat.value,
+      force
+    };
+    if (range.value === "custom") {
+      params.from = customDates.value[0];
+      params.to = customDates.value[1];
+    }
+
+    const data = await getDashboardHomeAPI(params);
+    if (!data?.data) {
+      throw new Error("仪表盘数据为空");
+    }
+    home.value = data.data;
+  } catch (error) {
+    if (retryCount < 3) {
+      dashboardRetryTimer = setTimeout(() => {
+        getDashboardHome(force, retryCount + 1);
+      }, (retryCount + 1) * 1000);
+      return;
+    }
+    console.error("获取首页统计失败:", error);
+  } finally {
+    loading.value = false;
+  }
 };
 
 // 处理法币切换
@@ -55,8 +126,26 @@ const handleFiatChange = (value: string) => {
   getDashboardHome();
 };
 
+const handleRangeChange = () => {
+  if (range.value !== "custom") {
+    getDashboardHome();
+  }
+};
+
+const handleCustomDateChange = () => {
+  getDashboardHome();
+};
+
+const forceRefresh = () => {
+  getDashboardHome(true);
+};
+
 onMounted(() => {
   getDashboardHome();
+});
+
+onUnmounted(() => {
+  clearDashboardRetry();
 });
 </script>
 
@@ -141,6 +230,14 @@ onMounted(() => {
   }
 }
 
+.range-actions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 10px;
+  margin-left: auto;
+}
+
 // 响应式设计
 @media (max-width: 768px) {
   .dashboard-toolbar {
@@ -164,6 +261,13 @@ onMounted(() => {
       min-width: auto;
       margin-bottom: 4px;
     }
+  }
+
+  .range-actions {
+    width: 100%;
+    flex-wrap: wrap;
+    justify-content: flex-start;
+    margin-left: 0;
   }
 }
 </style>


### PR DESCRIPTION
在 web 后台“首页”仪表盘，丰富了数据接口以方便查看更多统计数据。

1. 下拉菜单显示在右侧，下拉菜单选项：今天、最近7天、自定义，添加按钮：强制刷新 以强制清空缓存
2. 默认以 最近7天 显示
3. 收款趋势柱形图采用双柱形图，以天为单位，柱形图取值：订单总数、已支付订单、当日收款金额总和
4. 修改数据汇总卡片：订单总数、收款金额、待付订单、失败订单、统计周期，下标数据：已支付订单、支付成功率、确认中的订单、通知失败、时区数据
5. 使用 bepusdt 自有 go-cache 缓存避免重复计算请求

data 数据接口：

载荷：

`range: string` 范围："`7d`,`today`,`custom`"
`tz: string` 时区，例如 `Asia/Hong_Kong`，该数据是获取的用户当前的时区
`fiat: string` 货币符号，例如：`CNY` 法币代号
`force: bool` 可选，为真时会清空缓存

数据接口预览：

```
"data": {
    "range": "7d",
    "from": "2026-04-24T00:00:00+08:00",
    "to": "2026-04-30T23:59:59+08:00",
    "timezone": "Asia/Hong_Kong",
    "currency": "CNY",
    "kpi": {
        "orders_total": 1399,
        "orders_pending": 0,
        "orders_confirming": 0,
        "gmv_paid": "41621.19",
        "orders_success": 319,
        "orders_failed": 1,
        "notify_failed": 1,
        "order_success_rate": "99.01"
    },
    "token_map": {
        "BNB": 1111.96,
        "ETH": 0,
        "TRX": 1111.1100000000003,
        "USDC": 3333.5555555,
        "USDT": 1111111.6666
    },
    "points": [
        {
            "date": "2026-04-28",
            "orders_total": 68,
            "orders_success": 57,
            "orders_failed": 0,
            "gmv_paid": "6425.98"
        },
        {
            "date": "2026-04-29",
            "orders_total": 69,
            "orders_paid": 59,
            "orders_success": 58,
            "orders_failed": 0,
            "gmv_paid": "6990.96"
        },
        {
            "date": "2026-04-30",
            "orders_total": 10,
            "orders_success": 7,
            "orders_failed": 0,
            "gmv_paid": "620.17"
        }
    ]
}
```

points 用于显示收款趋势柱形图
gmv_paid 用于统计范围段内收款成功总和

效果图：

<img width="2111" height="1374" alt="screenshot_2026-05-05_20-03-17" src="https://github.com/user-attachments/assets/dfcb4831-7b94-4aea-b3ed-aa753c1382de" />
