### PR TITLE
添加 WooCommerce 对接插件链接

### DIFF
--- a/docs/api/other.md
+++ b/docs/api/other.md
@@ -22,4 +22,4 @@
 - [异次元发卡](acg-faka/README.md)
 - [萌次元商城](./mcy-faka/mcy-shop.md)
 - [EdgeKey](./edge-key/edge-key.md)
-
+- [WooCommerce/WordPress 收款插件-BEpusdt for WooCommerce](https://github.com/immonsterx/bepusdt-woocommerce)


### PR DESCRIPTION
在对接指南中添加 BEpusdt for WooCommerce 插件链接。

BEpusdt for WooCommerce 是一个轻量化的 WordPress + WooCommerce 加密货币收款插件。它会在 WooCommerce 中注册 BEpusdt Crypto 支付网关，创建 BEpusdt 支付交易，展示前端支付入口，并通过 BEpusdt 回调或 WordPress Cron 轮询同步 WooCommerce 订单状态。

项目地址：

https://github.com/immonsterx/bepusdt-woocommerce