### PR TITLE
fix(notifier): 使用归一化地址判断非订单转账方向

### DIFF
--- a/app/notifier/telegram.go
+++ b/app/notifier/telegram.go
@@ -141,10 +141,7 @@ func (t *Telegram) NotifyFail(o model.Order, reason string) {
 }
 
 func (t *Telegram) NonOrderTransfer(trans model.TronTransfer, wa model.Wallet) {
-	title := "收入"
-	if trans.RecvAddress != wa.Address {
-		title = "支出"
-	}
+	title := nonOrderTransferTitle(trans, wa)
 
 	text := fmt.Sprintf(
 		"\\#账户%s \\#非订单交易\n\\-\\-\\-\n```\n💲交易数额：%v \n💍交易类别："+strings.ToUpper(string(trans.TradeType))+"\n⏱️交易时间：%v\n✅接收地址：%v\n🅾️发送地址：%v```\n",
@@ -166,6 +163,14 @@ func (t *Telegram) NonOrderTransfer(trans model.TronTransfer, wa model.Wallet) {
 			},
 		},
 	})
+}
+
+func nonOrderTransferTitle(trans model.TronTransfer, wa model.Wallet) string {
+	if trans.RecvAddress == wa.MatchAddr {
+		return "收入"
+	}
+
+	return "支出"
 }
 
 func (t *Telegram) TronResourceChange(res model.TronResource) {

--- a/app/notifier/telegram_test.go
+++ b/app/notifier/telegram_test.go
@@ -1,0 +1,37 @@
+package notifier
+
+import (
+	"testing"
+
+	"github.com/v03413/bepusdt/app/model"
+)
+
+func TestNonOrderTransferTitleUsesMatchAddress(t *testing.T) {
+	trans := model.TronTransfer{
+		RecvAddress: "0xf9dff4e813644edc7d9b1b535100b7e92333f743",
+		FromAddress: "0x6cba0ff7e76b225ee3b975c3096d828f012c8c72",
+	}
+	wallet := model.Wallet{
+		Address:   "0xF9DFF4E813644eDc7D9b1b535100b7e92333f743",
+		MatchAddr: "0xf9dff4e813644edc7d9b1b535100b7e92333f743",
+	}
+
+	if title := nonOrderTransferTitle(trans, wallet); title != "收入" {
+		t.Fatalf("title = %q, want %q", title, "收入")
+	}
+}
+
+func TestNonOrderTransferTitleMarksOutgoingTransfer(t *testing.T) {
+	trans := model.TronTransfer{
+		RecvAddress: "0xrecipient",
+		FromAddress: "0xf9dff4e813644edc7d9b1b535100b7e92333f743",
+	}
+	wallet := model.Wallet{
+		Address:   "0xF9DFF4E813644eDc7D9b1b535100b7e92333f743",
+		MatchAddr: "0xf9dff4e813644edc7d9b1b535100b7e92333f743",
+	}
+
+	if title := nonOrderTransferTitle(trans, wallet); title != "支出" {
+		t.Fatalf("title = %q, want %q", title, "支出")
+	}
+}


### PR DESCRIPTION
## 概要

修复 Telegram 非订单转账通知中，EVM 钱包收入被误判为支出的问题。

扫块逻辑使用归一化后的 `match_addr` 来匹配钱包地址，但 Telegram 通知标题此前使用钱包原始 `address` 判断收支方向。EVM 地址可能保存为 EIP-55 混合大小写，而链上日志解析出的地址是小写，因此真实的 ERC20 入账会被误标为 `账户支出`。

本次修改改为使用 `MatchAddr` 判断通知标题，和非订单转账匹配逻辑保持一致。

## 测试

- `go test ./app/notifier -run 'TestNonOrderTransferTitle' -count=1 -timeout=30s`