### PR TITLE
feat: Admin can manually cancel unpaid orders

### DIFF
--- a/app/handler/admin/order.go
+++ b/app/handler/admin/order.go
@@ -201,6 +201,12 @@ func (Order) Paid(ctx *gin.Context) {
 		return
 	}
 
+	if order.Status == model.OrderStatusCanceled {
+		base.BadRequest(ctx, "交易已取消，无法补单")
+
+		return
+	}
+
 	confirmedAt := time.Now()
 	var update = map[string]interface{}{
 		"ref_hash":     req.RefHash,
@@ -253,6 +259,37 @@ func (Order) ManualNotify(ctx *gin.Context) {
 	}
 
 	base.Ok(ctx, "订单回调成功！")
+}
+
+func (Order) Cancel(ctx *gin.Context) {
+	var req base.IDRequest
+	if err := ctx.ShouldBindJSON(&req); err != nil {
+		base.BadRequest(ctx, err.Error())
+
+		return
+	}
+
+	var order model.Order
+	model.Db.Where("id = ?", req.ID).Find(&order)
+	if order.ID == 0 {
+		base.BadRequest(ctx, "订单不存在")
+
+		return
+	}
+
+	if order.Status != model.OrderStatusWaiting {
+		base.BadRequest(ctx, "仅允许取消未支付订单")
+
+		return
+	}
+
+	if err := order.SetCanceled(); err != nil {
+		base.Error(ctx, err)
+
+		return
+	}
+
+	base.Ok(ctx, "订单取消成功")
 }
 
 func (Order) Del(ctx *gin.Context) {

--- a/app/router/admin.go
+++ b/app/router/admin.go
@@ -38,6 +38,7 @@ func adminInit(e *gin.Engine) {
 		PostRegister(orderRtr, "/detail", true, orderHdr.Detail)
 		PostRegister(orderRtr, "/paid", true, orderHdr.Paid)
 		PostRegister(orderRtr, "/manual_notify", true, orderHdr.ManualNotify)
+		PostRegister(orderRtr, "/cancel", true, orderHdr.Cancel)
 		PostRegister(orderRtr, "/del", true, orderHdr.Del)
 	}
 

--- a/static/checkout/official/assets/js/checkout.js
+++ b/static/checkout/official/assets/js/checkout.js
@@ -309,13 +309,32 @@
                 var d = res.data;
                 if (d.status === 5) showConfirming();
                 else if (d.status === 2) {
-                    clearInterval(stTimer);
-                    if (cdTimer) clearInterval(cdTimer);
+                    stopTimers();
                     hideConfirming();
                     showSuccess(d);
+                } else if (d.status === 4) {
+                    showCanceled(d);
                 }
             })
             .catch(function (e) { console.error(e); });
+    }
+
+    function stopTimers() {
+        if (stTimer) {
+            clearInterval(stTimer);
+            stTimer = null;
+        }
+        if (cdTimer) {
+            clearInterval(cdTimer);
+            cdTimer = null;
+        }
+    }
+
+    function hideCheckoutStages() {
+        var selection = document.getElementById('selectionStage');
+        var payment = document.getElementById('paymentStage');
+        if (selection) selection.style.display = 'none';
+        if (payment) payment.style.display = 'none';
     }
 
     function startCountdown(timerEl, expiredAt, createdAt, onExpire) {
@@ -383,6 +402,35 @@
         showToast(t('paymentSuccessToast', '支付成功'), 'success');
     }
 
+    function showCanceled(data) {
+        stopTimers();
+        hideConfirming();
+        hideCheckoutStages();
+        var modal = document.getElementById('canceledModal');
+        if (!modal) {
+            var ret = (data && data.redirect_url) || (cfg && cfg.return_url) || '/';
+            modal = document.createElement('div');
+            modal.id = 'canceledModal';
+            modal.className = 'modal-overlay';
+            modal.innerHTML =
+                '<div class="modal-card"><div class="modal-body">' +
+                '<div style="margin-bottom:16px;display:flex;justify-content:center;">' +
+                    '<svg width="64" height="64" viewBox="0 0 24 24" fill="none" stroke="#64748b" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">' +
+                        '<circle cx="12" cy="12" r="10"/>' +
+                        '<path d="M15 9l-6 6"/>' +
+                        '<path d="M9 9l6 6"/>' +
+                    '</svg>' +
+                '</div>' +
+                '<div class="modal-title" style="color:#475569;">' + t('canceledTitle', '订单已取消') + '</div>' +
+                '<p class="modal-subtitle">' + t('canceledMessage', '该订单已取消，不能继续付款。<br>如需支付，请重新发起订单。') + '</p>' +
+                '<a href="' + ret + '" class="return-btn">' + t('returnBtn', '返回商户平台') + '</a>' +
+                '</div></div>';
+            document.body.appendChild(modal);
+        }
+        modal.style.display = 'flex';
+        showToast(t('orderCanceledToast', '订单已取消'), 'error');
+    }
+
     function showTimeout() {
         if (document.getElementById('timeoutModal')) return;
         var ret = cfg.return_url || '/';
@@ -405,6 +453,10 @@
     }
 
     function createTransaction() {
+        if (cfg && cfg.status && cfg.status !== 1) {
+            showToast(t('toastOrderNotPayable', '当前订单状态不允许继续付款'), 'error');
+            return;
+        }
         if (!selMethod) return;
         fetch('/api/v1/pay/update-order', {
             method: 'POST',
@@ -431,7 +483,10 @@
             startCountdown(document.getElementById('timerDisplay'), parseInt(cfg.expired_at) || 0, parseInt(cfg.created_at) || 0, showTimeout);
             startStatusCheck();
             var payBtn = document.getElementById('payBtn');
-            if (payBtn) payBtn.addEventListener('click', createTransaction);
+            if (payBtn && !payBtn.dataset.bound) {
+                payBtn.dataset.bound = '1';
+                payBtn.addEventListener('click', createTransaction);
+            }
             var caBtn = document.getElementById('copyAmountBtn');
             var caIcon = document.getElementById('copyAmountIcon');
             if (caBtn) caBtn.addEventListener('click', function () {
@@ -474,6 +529,7 @@
         initI18n: initI18n,
         applyI18n: applyI18n,
         t: t,
+        showCanceled: showCanceled,
         switchLang: switchLang
     };
 })();
@@ -496,7 +552,8 @@
             expired_at: d.expired_at,
             created_at: d.created_at,
             trade_id: d.trade_id,
-            return_url: d.redirect_url
+            return_url: d.redirect_url,
+            status: d.status
         });
     }
 
@@ -522,7 +579,8 @@
             expired_at: d.expired_at,
             created_at: d.created_at,
             trade_id: d.trade_id,
-            return_url: d.redirect_url
+            return_url: d.redirect_url,
+            status: d.status
         });
     }
 
@@ -559,6 +617,10 @@
                     return;
                 }
                 orderData = res.data;
+                if (orderData.status === 4) {
+                    if (window.Payment && Payment.showCanceled) Payment.showCanceled(orderData);
+                    return;
+                }
                 if (!orderData.trade_type || !orderData.token) showSelection();
                 else showPayment();
             })
@@ -579,7 +641,3 @@
         ready.then(loadOrder);
     });
 })();
-
-
-
-

--- a/static/checkout/official/assets/locales/en.json
+++ b/static/checkout/official/assets/locales/en.json
@@ -26,6 +26,7 @@
   "toastCreateFailed": "Failed to create transaction",
   "toastLoadFailed": "Failed to load payment network",
   "toastLoadOrderFailed": "Failed to load order",
+  "toastOrderNotPayable": "The current order status does not allow payment",
   "paymentSuccess": "Payment Successful!",
   "paymentSuccessSubtitle": "Your payment has been confirmed, transaction complete",
   "onChainDetails": "On-chain Details",
@@ -35,5 +36,8 @@
   "confirmingNote": "Estimated confirmation time: 1-3 minutes",
   "timeoutTitle": "Payment Expired",
   "timeoutMessage": "Sorry, the payment time has expired.<br>Please initiate a new payment.",
-  "paymentSuccessToast": "Payment successful"
+  "paymentSuccessToast": "Payment successful",
+  "canceledTitle": "Order Canceled",
+  "canceledMessage": "This order has been canceled and can no longer be paid.<br>Please create a new order to continue.",
+  "orderCanceledToast": "Order canceled"
 }

--- a/static/checkout/official/assets/locales/zh.json
+++ b/static/checkout/official/assets/locales/zh.json
@@ -26,6 +26,7 @@
   "toastCreateFailed": "创建交易失败",
   "toastLoadFailed": "无法加载付款网络",
   "toastLoadOrderFailed": "加载订单失败",
+  "toastOrderNotPayable": "当前订单状态不允许继续付款",
   "paymentSuccess": "支付成功！",
   "paymentSuccessSubtitle": "您的付款已确认，交易已完成",
   "onChainDetails": "链上详情",
@@ -35,5 +36,8 @@
   "confirmingNote": "预计确认时间：1-3 分钟",
   "timeoutTitle": "支付已超时",
   "timeoutMessage": "很抱歉，支付时间已超时。<br>请重新发起支付。",
-  "paymentSuccessToast": "支付成功"
+  "paymentSuccessToast": "支付成功",
+  "canceledTitle": "订单已取消",
+  "canceledMessage": "该订单已取消，不能继续付款。<br>如需支付，请重新发起订单。",
+  "orderCanceledToast": "订单已取消"
 }

--- a/web/src/api/modules/order/index.ts
+++ b/web/src/api/modules/order/index.ts
@@ -32,6 +32,14 @@ export const paidAPI = (data: any) => {
   });
 };
 
+export const cancelOrderAPI = (data: any) => {
+  return axios({
+    url: "/api/order/cancel",
+    method: "post",
+    data
+  });
+};
+
 export const delOrderApi = (data: any) => {
   return axios({
     url: "/api/order/del",

--- a/web/src/views/order/components/detail.vue
+++ b/web/src/views/order/components/detail.vue
@@ -19,6 +19,17 @@
           <template #icon><icon-notification /></template>
           回调
         </a-button>
+        <a-popconfirm
+          v-if="detailData.status === 1"
+          content="确定取消该订单吗？取消后用户将无法继续支付。"
+          type="warning"
+          @ok="handleCancelOrder"
+        >
+          <a-button type="primary" status="warning">
+            <template #icon><icon-close-circle /></template>
+            取消订单
+          </a-button>
+        </a-popconfirm>
         <a-popconfirm content="确定删除该订单吗？删除后将无法恢复！" type="error" @ok="handleDelete">
           <a-button type="primary" status="danger">
             <template #icon><icon-delete /></template>
@@ -258,9 +269,8 @@
 
 <script setup lang="ts">
 import { getCryptoColor } from "@/views/rate/common";
-import { delOrderApi } from "@/api/modules/order/index";
+import { cancelOrderAPI, delOrderApi, manualNotifyAPI } from "@/api/modules/order/index";
 import { Notification, Modal } from "@arco-design/web-vue";
-import { manualNotifyAPI } from "@/api/modules/order/index";
 import { useLayoutModel } from "@/hooks/useLayoutModel";
 
 const props = defineProps({
@@ -305,6 +315,17 @@ const handleDelete = async () => {
   try {
     await delOrderApi({ ids: [props.detailData.id] });
     Notification.success("删除成功");
+    emits("refresh");
+    onClose();
+  } catch (error) {
+    Notification.error(error);
+  }
+};
+
+const handleCancelOrder = async () => {
+  try {
+    await cancelOrderAPI({ id: props.detailData.id });
+    Notification.success("订单已取消");
     emits("refresh");
     onClose();
   } catch (error) {

--- a/web/src/views/order/order.vue
+++ b/web/src/views/order/order.vue
@@ -123,7 +123,7 @@
         <template #optional="{ record }">
           <a-space wrap>
             <a-button size="mini" type="primary" @click="showDetail(record)">详情</a-button>
-            <a-button size="mini" type="primary" status="warning" :disabled="record.status === 2" @click="showPaidModal(record)">
+            <a-button size="mini" type="primary" status="warning" :disabled="!canManualPaid(record)" @click="showPaidModal(record)">
               补单
             </a-button>
           </a-space>
@@ -132,7 +132,7 @@
     </div>
   </div>
 
-  <DetailModal :visible="detailVisible" :detailData="detailData" @close="closeDetail" />
+  <DetailModal :visible="detailVisible" :detailData="detailData" @close="closeDetail" @refresh="getOrderList" />
 
   <!-- 补单弹窗 -->
   <a-modal
@@ -314,7 +314,11 @@ const paidForm = reactive({
   recordId: 0
 });
 
+const canManualPaid = (record: List) => record.status !== 2 && record.status !== 4;
+
 const showPaidModal = (record: List) => {
+  if (!canManualPaid(record)) return;
+
   paidForm.recordId = record.id;
   paidForm.ref_hash = "";
   paidModalVisible.value = true;


### PR DESCRIPTION
增加 /cancel 取消订单 API
允许管理员手动取消客户不再需要付款的未付款的订单，可用于释放 task，不必等订单过期。

前端收银台：
1. 独立 stopTimers 方法更好一些。
2. 已取消付款的弹窗，使用 hideCheckoutStages 完全隐藏货币选择和支付画面。