### PR TITLE
feat: Add the ability to reselect order trade types

### DIFF
--- a/app/handler/admin/order.go
+++ b/app/handler/admin/order.go
@@ -52,15 +52,18 @@ func (Order) Create(ctx *gin.Context) {
 
 	host := utils.GetRequestHost(ctx.Request)
 
+	tradeTypeReselect := model.OrderTradeTypeReselectEnabled()
+
 	// 创建待付款订单
 	order, err := model.BuildPendingOrder(model.OrderParams{
-		Money:         decimal.NewFromFloat(req.Amount),
-		ApiType:       model.OrderApiTypeAdmin, // 使用 Admin 类型
-		OrderId:       req.OrderID,
-		Name:          req.Name,
-		Timeout:       req.Timeout,
-		Fiat:          req.Fiat,
-		CurrencyLimit: req.Currencies,
+		Money:             decimal.NewFromFloat(req.Amount),
+		ApiType:           model.OrderApiTypeAdmin, // 使用 Admin 类型
+		OrderId:           req.OrderID,
+		Name:              req.Name,
+		Timeout:           req.Timeout,
+		Fiat:              req.Fiat,
+		CurrencyLimit:     req.Currencies,
+		TradeTypeReselect: tradeTypeReselect,
 	})
 	if err != nil {
 		base.Response(ctx, 400, gin.H{
@@ -80,6 +83,9 @@ func (Order) Create(ctx *gin.Context) {
 	}
 	order.NotifyUrl = hostUri + "/api/v1/pay/notify"
 	order.ReturnUrl = url
+	if order.Status == model.OrderStatusWaiting {
+		order.TradeTypeReselect = tradeTypeReselect
+	}
 
 	if err := model.Db.Save(&order).Error; err != nil {
 		base.Response(ctx, 400, gin.H{

--- a/app/handler/epusdt/epusdt.go
+++ b/app/handler/epusdt/epusdt.go
@@ -40,6 +40,7 @@ type createOrderReq struct {
 	Fiat        model.Fiat `json:"fiat"`
 	Currencies  string     `json:"currencies"`
 	Timeout     int64      `json:"timeout"`
+	Reselect    *bool      `json:"reselect"`
 }
 
 type updateOrderReq struct {
@@ -60,6 +61,15 @@ type infoReq struct {
 type methodsReq struct {
 	TradeID  string `json:"trade_id" binding:"required"`
 	Currency string `json:"currency"`
+}
+
+// tradeTypeReselect 返回本次 create-order 是否允许确认交易类型后再次重选；未传 reselect 时使用后台全局配置。
+func (r createOrderReq) tradeTypeReselect() bool {
+	if r.Reselect == nil {
+		return model.OrderTradeTypeReselectEnabled()
+	}
+
+	return *r.Reselect
 }
 
 func (Epusdt) Notify(ctx *gin.Context) {
@@ -120,15 +130,16 @@ func (Epusdt) CreateOrder(ctx *gin.Context) {
 
 	// 创建待付款订单
 	order, err := model.BuildPendingOrder(model.OrderParams{
-		Money:         decimal.NewFromFloat(req.Amount),
-		ApiType:       model.OrderApiTypeEpusdt,
-		OrderId:       req.OrderID,
-		RedirectUrl:   req.RedirectURL,
-		NotifyUrl:     req.NotifyURL,
-		Name:          req.Name,
-		Timeout:       req.Timeout,
-		Fiat:          req.Fiat,
-		CurrencyLimit: req.Currencies,
+		Money:             decimal.NewFromFloat(req.Amount),
+		ApiType:           model.OrderApiTypeEpusdtOrder,
+		OrderId:           req.OrderID,
+		RedirectUrl:       req.RedirectURL,
+		NotifyUrl:         req.NotifyURL,
+		Name:              req.Name,
+		Timeout:           req.Timeout,
+		Fiat:              req.Fiat,
+		CurrencyLimit:     req.Currencies,
+		TradeTypeReselect: req.tradeTypeReselect(),
 	})
 	if err != nil {
 		ctx.JSON(200, respFailJson(fmt.Sprintf("CreateOrder: order create failed: %s", err.Error())))
@@ -148,6 +159,7 @@ func (Epusdt) CreateOrder(ctx *gin.Context) {
 		"expiration_time": uint64(order.ExpiredAt.Sub(time.Now()).Seconds()),
 		"payment_url":     model.CheckoutUrl(host, order.TradeId),
 		"network":         order.GetMethods(""),
+		"reselect":        order.CanReselectPayment(),
 	}))
 }
 
@@ -172,8 +184,21 @@ func (Epusdt) UpdateOrder(ctx *gin.Context) {
 		return
 	}
 
-	if order.TradeType != "" {
-		ctx.JSON(200, respFailJson("update order failed: order already has trade type"))
+	// 仅待付订单才可更新订单
+	if order.Status != model.OrderStatusWaiting {
+		ctx.JSON(200, respFailJson("update order failed: order status does not allow payment updates"))
+		return
+	}
+
+	if order.TradeType != "" && !order.CanReselectPayment() {
+		ctx.JSON(200, respFailJson("update order failed: order status does not allow payment updates"))
+		return
+	}
+
+	// 拒绝任务未及时改成 expired，实际订单已过期时更新订单
+	remaining := time.Until(order.ExpiredAt)
+	if remaining <= 0 {
+		ctx.JSON(200, respFailJson("update order failed: order expired"))
 		return
 	}
 
@@ -188,14 +213,15 @@ func (Epusdt) UpdateOrder(ctx *gin.Context) {
 	// 注意：RebuildOrder 需要 OrderParams，我们需要从现有订单构造参数
 	money, _ := decimal.NewFromString(order.Money)
 	params := model.OrderParams{
-		Money:       money,
-		OrderId:     order.OrderId,
-		TradeType:   tradeType, // 新的交易类型
-		RedirectUrl: order.ReturnUrl,
-		NotifyUrl:   order.NotifyUrl,
-		Name:        order.Name,
-		Timeout:     int64(order.ExpiredAt.Sub(time.Now()).Seconds()),
-		Fiat:        order.Fiat,
+		Money:             money,
+		OrderId:           order.OrderId,
+		TradeType:         tradeType, // 新的交易类型
+		RedirectUrl:       order.ReturnUrl,
+		NotifyUrl:         order.NotifyUrl,
+		Name:              order.Name,
+		Timeout:           int64(math.Ceil(remaining.Seconds())),
+		Fiat:              order.Fiat,
+		TradeTypeReselect: order.TradeTypeReselect,
 	}
 
 	newOrder, err := model.RebuildOrder(order, params)
@@ -339,8 +365,13 @@ func (Epusdt) GetMethods(ctx *gin.Context) {
 		return
 	}
 
-	if order.Status == model.OrderStatusExpired {
-		ctx.JSON(200, respFailJson("order expired"))
+	if order.Status != model.OrderStatusWaiting {
+		ctx.JSON(200, respFailJson("error: Invalid order status"))
+		return
+	}
+
+	if order.TradeType != "" && !order.CanReselectPayment() {
+		ctx.JSON(200, respFailJson("error: The order status does not allow retrieving the payment method"))
 		return
 	}
 
@@ -378,6 +409,7 @@ func (Epusdt) Info(ctx *gin.Context) {
 		"trade_url":     order.GetTxUrl(),                    // 链上详情
 		"support_url":   model.GetC(model.PaymentSupportUrl), // 客服链接
 		"redirect_url":  order.RedirectUrl(),                 // 跳转地址
+		"reselect":      order.CanReselectPayment(),          // 是否允许确认交易类型后重选
 	}))
 }
 

--- a/app/model/conf.go
+++ b/app/model/conf.go
@@ -47,6 +47,7 @@ var defaultConf = map[ConfKey]string{
 	PaymentMatchMode:        string(Classic),
 	PaymentSupportUrl:       "",
 	PaymentLookbackHour:     "3",
+	OrderTradeTypeReselect:  "1",
 	SystemInstallLock:       "0",
 	RateSyncCoingeckoApiUrl: "https://api.coingecko.com",
 	RateSyncHistoryDays:     "30",
@@ -205,6 +206,10 @@ func ConfInit() {
 func AuthToken() string {
 
 	return GetK(ApiAuthToken)
+}
+
+func OrderTradeTypeReselectEnabled() bool {
+	return cast.ToBool(GetC(OrderTradeTypeReselect))
 }
 
 func IsInstalled() bool {

--- a/app/model/const.go
+++ b/app/model/const.go
@@ -45,14 +45,15 @@ const (
 	AtomETH  ConfKey = "atom_eth"
 	AtomGRAM ConfKey = "atom_gram"
 
-	MonitorMinAmount    ConfKey = "monitor_min_amount" // 监控最小金额，低于此金额的入账不进行通知
-	PaymentMinAmount    ConfKey = "payment_min_amount"
-	PaymentMaxAmount    ConfKey = "payment_max_amount"
-	PaymentTimeout      ConfKey = "payment_timeout"       // 订单支付超时时间，单位秒
-	PaymentCheckout     ConfKey = "payment_checkout"      // 收银台模板
-	PaymentMatchMode    ConfKey = "payment_match_mode"    // 订单金额匹配模式
-	PaymentSupportUrl   ConfKey = "payment_support_url"   // 订单支付客服链接
-	PaymentLookbackHour ConfKey = "payment_lookback_hour" // 订单回溯时间
+	MonitorMinAmount       ConfKey = "monitor_min_amount" // 监控最小金额，低于此金额的入账不进行通知
+	PaymentMinAmount       ConfKey = "payment_min_amount"
+	PaymentMaxAmount       ConfKey = "payment_max_amount"
+	PaymentTimeout         ConfKey = "payment_timeout"           // 订单支付超时时间，单位秒
+	PaymentCheckout        ConfKey = "payment_checkout"          // 收银台模板
+	PaymentMatchMode       ConfKey = "payment_match_mode"        // 订单金额匹配模式
+	PaymentSupportUrl      ConfKey = "payment_support_url"       // 订单支付客服链接
+	PaymentLookbackHour    ConfKey = "payment_lookback_hour"     // 订单回溯时间
+	OrderTradeTypeReselect ConfKey = "order_trade_type_reselect" // 订单交易类型重选
 
 	RpcEndpointPlasma         ConfKey = "rpc_endpoint_plasma"            // Plasma RPC节点
 	RpcEndpointBsc            ConfKey = "rpc_endpoint_bsc"               // BSC RPC节点

--- a/app/model/order.go
+++ b/app/model/order.go
@@ -55,37 +55,39 @@ const (
 )
 
 const (
-	OrderApiTypeEpusdt = "epusdt" // epusdt
-	OrderApiTypeEpay   = "epay"   // 彩虹易支付
-	OrderApiTypeAdmin  = "admin"  // 管理后台
+	OrderApiTypeEpusdt      = "epusdt"       // epusdt
+	OrderApiTypeEpusdtOrder = "epusdt_order" // epusdt create-order
+	OrderApiTypeEpay        = "epay"         // 彩虹易支付
+	OrderApiTypeAdmin       = "admin"        // 管理后台
 )
 
 type Order struct {
 	Id
-	OrderId       string     `gorm:"column:order_id;type:varchar(128);not null;index;comment:商户ID" json:"order_id"`
-	TradeId       string     `gorm:"column:trade_id;type:varchar(128);not null;uniqueIndex;comment:本地ID" json:"trade_id"`
-	TradeType     TradeType  `gorm:"column:trade_type;type:varchar(20);not null;index;comment:交易类型" json:"trade_type"`
-	Fiat          Fiat       `gorm:"column:fiat;type:varchar(16);not null;index;default:CNY;comment:法定货币" json:"fiat"`
-	Crypto        Crypto     `gorm:"column:crypto;type:varchar(16);not null;index;default:USDT;comment:加密货币" json:"crypto"`
-	CurrencyLimit string     `gorm:"column:currency_limit;type:varchar(255);not null;default:'';comment:限定币种" json:"currency_limit"`
-	Rate          string     `gorm:"column:rate;type:varchar(10);not null;comment:交易汇率" json:"rate"`
-	Amount        string     `gorm:"column:amount;type:varchar(32);not null;default:0.00;comment:交易数额" json:"amount"`
-	Money         string     `gorm:"column:money;type:varchar(32);not null;default:0.00;comment:交易金额" json:"money"`
-	Address       string     `gorm:"column:address;type:varchar(128);index;not null;comment:收款地址" json:"address"`
-	FromAddress   string     `gorm:"column:from_address;type:varchar(128);not null;default:'';comment:支付地址" json:"from_address"`
-	MatchAddress  string     `gorm:"column:match_address;type:varchar(128);not null;default:'';comment:校验地址" json:"match_address"`
-	AddressLocked bool       `gorm:"column:address_locked;not null;default:false;comment:地址锁定 1:独占 0:共享" json:"address_locked"`
-	Status        int        `gorm:"column:status;not null;default:1;index;index:idx_order_notify_retry,priority:1;comment:交易状态" json:"status"`
-	Name          string     `gorm:"column:name;type:varchar(64);not null;default:'';comment:商品名称" json:"name"`
-	ApiType       string     `gorm:"column:api_type;type:varchar(20);not null;default:'epusdt';comment:API类型" json:"api_type"`
-	ReturnUrl     string     `gorm:"column:return_url;type:varchar(255);not null;default:'';comment:同步地址" json:"return_url"`
-	NotifyUrl     string     `gorm:"column:notify_url;type:varchar(255);not null;default:'';comment:异步地址" json:"notify_url"`
-	NotifyNum     int        `gorm:"column:notify_num;not null;default:0;index:idx_order_notify_retry,priority:3;comment:回调次数" json:"notify_num"`
-	NotifyState   int        `gorm:"column:notify_state;not null;default:0;index:idx_order_notify_retry,priority:2;comment:回调状态 1：成功 0：失败" json:"notify_state"`
-	RefHash       string     `gorm:"column:ref_hash;type:varchar(128);not null;default:'';index;comment:交易哈希" json:"ref_hash"`
-	RefBlockNum   int        `gorm:"column:ref_block_num;not null;default:0;comment:区块索引" json:"ref_block_num"`
-	ExpiredAt     time.Time  `gorm:"column:expired_at;not null;comment:失效时间" json:"expired_at"`
-	ConfirmedAt   *time.Time `gorm:"column:confirmed_at;not null;comment:交易确认时间" json:"confirmed_at"`
+	OrderId           string     `gorm:"column:order_id;type:varchar(128);not null;index;comment:商户ID" json:"order_id"`
+	TradeId           string     `gorm:"column:trade_id;type:varchar(128);not null;uniqueIndex;comment:本地ID" json:"trade_id"`
+	TradeType         TradeType  `gorm:"column:trade_type;type:varchar(20);not null;index;comment:交易类型" json:"trade_type"`
+	TradeTypeReselect bool       `gorm:"column:trade_type_reselect;not null;comment:允许订单交易类型重选" json:"trade_type_reselect"`
+	Fiat              Fiat       `gorm:"column:fiat;type:varchar(16);not null;index;default:CNY;comment:法定货币" json:"fiat"`
+	Crypto            Crypto     `gorm:"column:crypto;type:varchar(16);not null;index;default:USDT;comment:加密货币" json:"crypto"`
+	CurrencyLimit     string     `gorm:"column:currency_limit;type:varchar(255);not null;default:'';comment:限定币种" json:"currency_limit"`
+	Rate              string     `gorm:"column:rate;type:varchar(10);not null;comment:交易汇率" json:"rate"`
+	Amount            string     `gorm:"column:amount;type:varchar(32);not null;default:0.00;comment:交易数额" json:"amount"`
+	Money             string     `gorm:"column:money;type:varchar(32);not null;default:0.00;comment:交易金额" json:"money"`
+	Address           string     `gorm:"column:address;type:varchar(128);index;not null;comment:收款地址" json:"address"`
+	FromAddress       string     `gorm:"column:from_address;type:varchar(128);not null;default:'';comment:支付地址" json:"from_address"`
+	MatchAddress      string     `gorm:"column:match_address;type:varchar(128);not null;default:'';comment:校验地址" json:"match_address"`
+	AddressLocked     bool       `gorm:"column:address_locked;not null;default:false;comment:地址锁定 1:独占 0:共享" json:"address_locked"`
+	Status            int        `gorm:"column:status;not null;default:1;index;index:idx_order_notify_retry,priority:1;comment:交易状态" json:"status"`
+	Name              string     `gorm:"column:name;type:varchar(64);not null;default:'';comment:商品名称" json:"name"`
+	ApiType           string     `gorm:"column:api_type;type:varchar(20);not null;default:'epusdt';comment:API类型" json:"api_type"`
+	ReturnUrl         string     `gorm:"column:return_url;type:varchar(255);not null;default:'';comment:同步地址" json:"return_url"`
+	NotifyUrl         string     `gorm:"column:notify_url;type:varchar(255);not null;default:'';comment:异步地址" json:"notify_url"`
+	NotifyNum         int        `gorm:"column:notify_num;not null;default:0;index:idx_order_notify_retry,priority:3;comment:回调次数" json:"notify_num"`
+	NotifyState       int        `gorm:"column:notify_state;not null;default:0;index:idx_order_notify_retry,priority:2;comment:回调状态 1：成功 0：失败" json:"notify_state"`
+	RefHash           string     `gorm:"column:ref_hash;type:varchar(128);not null;default:'';index;comment:交易哈希" json:"ref_hash"`
+	RefBlockNum       int        `gorm:"column:ref_block_num;not null;default:0;comment:区块索引" json:"ref_block_num"`
+	ExpiredAt         time.Time  `gorm:"column:expired_at;not null;comment:失效时间" json:"expired_at"`
+	ConfirmedAt       *time.Time `gorm:"column:confirmed_at;not null;comment:交易确认时间" json:"confirmed_at"`
 	AutoTimeAt
 }
 
@@ -106,6 +108,19 @@ func (o *Order) SetCanceled() error {
 	o.Status = OrderStatusCanceled
 
 	return Db.Save(o).Error
+}
+
+// CanReselectPayment 判断订单是否支持重选交易类型
+func (o *Order) CanReselectPayment() bool {
+	if o.Status != OrderStatusWaiting {
+		return false
+	}
+
+	if o.ApiType != OrderApiTypeEpusdtOrder && o.ApiType != OrderApiTypeAdmin {
+		return false
+	}
+
+	return o.TradeTypeReselect
 }
 
 func (o *Order) SetExpired() {
@@ -202,9 +217,10 @@ func (o *Order) BuildNotifyParams() string {
 
 func (o *Order) GetMethods(crypto Crypto) []MethodItem {
 	var items = make([]MethodItem, 0)
-	if o.TradeType != "" {
-		// 已经选好了付款网络，没必要再给出可选项
-
+	if o.Status != OrderStatusWaiting {
+		return items
+	}
+	if o.TradeType != "" && !o.CanReselectPayment() {
 		return items
 	}
 

--- a/app/model/trade.go
+++ b/app/model/trade.go
@@ -13,19 +13,20 @@ import (
 )
 
 type OrderParams struct {
-	Money         decimal.Decimal `json:"money"`          // 交易金额 (单位：法币)s
-	ApiType       string          `json:"api_type"`       // 支付 API 类型
-	Address       string          `json:"address"`        // 收款地址
-	OrderId       string          `json:"order_id"`       // 商户订单 ID
-	TradeType     TradeType       `json:"trade_type"`     // 交易类型
-	RedirectUrl   string          `json:"redirect_url"`   // 成功跳转地址
-	NotifyUrl     string          `json:"notify_url"`     // 异步通知地址
-	Name          string          `json:"name"`           // 商品名称
-	Timeout       int64           `json:"timeout"`        // 订单超时时间（秒）
-	Rate          string          `json:"rate"`           // 强制指定汇率
-	Fiat          Fiat            `json:"fiat"`           // 法币类型
-	CurrencyLimit string          `json:"currency_limit"` // 限定币种
-	AddressLocked bool            `json:"address_locked"` // 地址独占锁定
+	Money             decimal.Decimal `json:"money"`               // 交易金额 (单位：法币)s
+	ApiType           string          `json:"api_type"`            // 支付 API 类型
+	Address           string          `json:"address"`             // 收款地址
+	OrderId           string          `json:"order_id"`            // 商户订单 ID
+	TradeType         TradeType       `json:"trade_type"`          // 交易类型
+	RedirectUrl       string          `json:"redirect_url"`        // 成功跳转地址
+	NotifyUrl         string          `json:"notify_url"`          // 异步通知地址
+	Name              string          `json:"name"`                // 商品名称
+	Timeout           int64           `json:"timeout"`             // 订单超时时间（秒）
+	Rate              string          `json:"rate"`                // 强制指定汇率
+	Fiat              Fiat            `json:"fiat"`                // 法币类型
+	CurrencyLimit     string          `json:"currency_limit"`      // 限定币种
+	AddressLocked     bool            `json:"address_locked"`      // 地址独占锁定
+	TradeTypeReselect bool            `json:"trade_type_reselect"` // 允许订单交易类型重选
 }
 
 type Addr struct {
@@ -98,28 +99,29 @@ func BuildOrder(p OrderParams, trade Trade) (Order, error) {
 
 	zero := time.Unix(0, 0)
 	tradeOrder := Order{
-		OrderId:       p.OrderId,
-		TradeId:       tradeId,
-		RefHash:       tradeId,
-		TradeType:     p.TradeType,
-		Rate:          fmt.Sprintf("%v", trade.Rate),
-		Amount:        trade.Amount,
-		Money:         p.Money.String(),
-		Address:       trade.Wallet.GetPaymentAddr(),
-		MatchAddress:  trade.Wallet.GetMatchAddr(),
-		AddressLocked: p.Money.IsZero(), // 零值订单，地址锁定 独占
-		Status:        OrderStatusWaiting,
-		Name:          p.Name,
-		ApiType:       p.ApiType,
-		ReturnUrl:     p.RedirectUrl,
-		NotifyUrl:     p.NotifyUrl,
-		NotifyNum:     0,
-		NotifyState:   OrderNotifyStateFail,
-		ExpiredAt:     CalcTradeExpiredAt(p.Timeout),
-		Fiat:          p.Fiat,
-		Crypto:        trade.Crypto,
-		CurrencyLimit: p.CurrencyLimit,
-		ConfirmedAt:   &zero, // 默认填充一个0值时间，尽量避免数据库出现允许 NULL 值存在
+		OrderId:           p.OrderId,
+		TradeId:           tradeId,
+		RefHash:           tradeId,
+		TradeType:         p.TradeType,
+		TradeTypeReselect: p.TradeTypeReselect,
+		Rate:              fmt.Sprintf("%v", trade.Rate),
+		Amount:            trade.Amount,
+		Money:             p.Money.String(),
+		Address:           trade.Wallet.GetPaymentAddr(),
+		MatchAddress:      trade.Wallet.GetMatchAddr(),
+		AddressLocked:     p.Money.IsZero(), // 零值订单，地址锁定 独占
+		Status:            OrderStatusWaiting,
+		Name:              p.Name,
+		ApiType:           p.ApiType,
+		ReturnUrl:         p.RedirectUrl,
+		NotifyUrl:         p.NotifyUrl,
+		NotifyNum:         0,
+		NotifyState:       OrderNotifyStateFail,
+		ExpiredAt:         CalcTradeExpiredAt(p.Timeout),
+		Fiat:              p.Fiat,
+		Crypto:            trade.Crypto,
+		CurrencyLimit:     p.CurrencyLimit,
+		ConfirmedAt:       &zero, // 默认填充一个0值时间，尽量避免数据库出现允许 NULL 值存在
 	}
 
 	if tradeOrder.Name == "" {
@@ -195,6 +197,7 @@ func RebuildOrder(t Order, p OrderParams) (Order, error) {
 	t.Amount = data.Amount
 	t.Money = p.Money.String()
 	t.TradeType = p.TradeType
+	t.TradeTypeReselect = p.TradeTypeReselect
 	t.Rate = fmt.Sprintf("%v", data.Rate)
 	t.ExpiredAt = CalcTradeExpiredAt(p.Timeout)
 

--- a/app/task/notify/notify.go
+++ b/app/task/notify/notify.go
@@ -161,7 +161,7 @@ func epusdt(ctx context.Context, order model.Order) error {
 }
 
 func Bepusdt(o model.Order) {
-	if o.ApiType != model.OrderApiTypeEpusdt {
+	if o.ApiType != model.OrderApiTypeEpusdt && o.ApiType != model.OrderApiTypeEpusdtOrder {
 
 		return
 	}

--- a/docs/api/api.md
+++ b/docs/api/api.md
@@ -182,6 +182,9 @@ POST /api/v1/order/create-order
 | fiat         | string | ❌  | 法币类型，默认 `CNY`<br/>可选：`CNY`、`USD`、`EUR`、`GBP`、`JPY`                                                                                       |
 | name         | string | ❌  | 商品名称                                                                                                                                     |
 | timeout      | number | ❌  | 订单超时时间（秒），最低 180 秒<br/>留空则使用配置 `payment_timeout`，默认 600 秒                                                                                |
+| reselect     | boolean | ❌  | 是否允许用户确认付款币种/网络后再次返回重选。<br/>仅对 `create-order` 创建的收银台订单生效；不传则使用后台“订单交易类型重选”全局开关，默认开启                                             |
+
+> 传入 `reselect` 时，该参数需要参与签名计算。boolean 值按 JSON 布尔值传递，并按 `true` / `false` 小写字符串参与签名拼接。
 
 #### 请求示例
 
@@ -195,6 +198,7 @@ POST /api/v1/order/create-order
   "notify_url": "https://example.com/notify",
   "redirect_url": "https://example.com/success",
   "timeout": 1200,
+  "reselect": true,
   "signature": "1cd4b52df5587cfb1968b0c0c6e156cd"
 }
 ```
@@ -212,6 +216,7 @@ POST /api/v1/order/create-order
 | data.status          | string | 订单状态，1 表示待付款 |
 | data.expiration_time | number | 订单有效期（秒）     |
 | data.payment_url     | string | 收银台订单链接      |
+| data.reselect        | boolean | 当前订单是否允许用户确认付款币种/网络后再次返回重选。该值与 `/api/v1/pay/info` 的 `reselect` 语义一致，取自订单当前状态与订单自身配置 |
 
 #### 响应示例
 
@@ -225,11 +230,14 @@ POST /api/v1/order/create-order
     "order_id": "20250120001",
     "amount": "28.88",
     "expiration_time": 1200,
+    "reselect": true,
     "payment_url": "https://example.com/pay/cashier/b3d2477c-d945-41da-96b7-f925bbd1b415"
   },
   "request_id": ""
 }
 ```
+
+> `reselect` 为 `true` 时，收银台可在用户选定付款币种/网络后提供“返回重选”入口；为 `false` 时，用户确认付款方式后不能再次切换。普通 `create-transaction` 创建的订单不支持交易类型重选。
 
 </details>
 
@@ -238,7 +246,7 @@ POST /api/v1/order/create-order
 <details>
 <summary><strong>4. 更新订单付款方式</strong>　为收银台订单选定支付链，获取具体收款地址与金额。</summary>
 
-> **注意**：使用相同 `trade_id` 更新订单时，系统会根据最新交易类型更新订单付款方式。
+> **注意**：使用相同 `trade_id` 更新订单时，系统会根据最新交易类型更新订单付款方式。若订单已选定付款方式，则只有 `reselect` 为 `true` 且订单仍处于待支付状态时，才允许再次调用本接口切换付款币种/网络。
 
 #### 请求地址
 
@@ -486,10 +494,11 @@ MD5(amount=42&notify_url=http://example.com/notify&order_id=20220201030210321&re
 
 ### 2. 订单重建机制是什么？
 
-当使用相同 `order_id` 创建订单时：
+当使用相同 `order_id` 创建订单时，不同接口的处理方式不同：
 
-- ✅ 更新订单金额、交易类型、收款地址、法币类型
-- ✅ **会** 重置超时时间
+- `create-transaction`：如果旧订单仍处于待支付状态，会按新参数重建订单，并重新计算超时时间
+- `create-order`：如果旧订单仍处于待支付状态，会返回已有订单，不会重置超时时间；后续调用 `update-order` 选择或重选付款币种/网络时，也会保留订单剩余有效期
+- 已支付成功或确认中的订单不会被重建
 
 ### 3. 支持哪些交易类型？
 

--- a/static/checkout/langge/assets/css/checkout.css
+++ b/static/checkout/langge/assets/css/checkout.css
@@ -108,6 +108,10 @@ button {
     display: flex;
 }
 
+[hidden] {
+    display: none !important;
+}
+
 .brand-mark {
     align-items: center;
     gap: 12px;

--- a/static/checkout/langge/assets/js/checkout.js
+++ b/static/checkout/langge/assets/js/checkout.js
@@ -15,6 +15,7 @@
     var currentLang = 'zh';
     var currentStatusKey = 'status.waitingPayment';
     var orderData = null;
+    var reselectingPayment = false;
 
     var translations = {
         zh: {
@@ -804,6 +805,21 @@
         setText('#orderAmount', moneyLabel(orderData.money, orderData.fiat));
         bindSupportLink(orderData.support_url);
         startCountdown();
+        updateReselectControls();
+    }
+
+    function canReselectPayment() {
+        return !!(orderData && orderData.reselect);
+    }
+
+    function updateReselectControls() {
+        var button = $('#backToMethodButton');
+        if (button) {
+            var visible = canReselectPayment();
+            button.hidden = !visible;
+            button.style.display = visible ? '' : 'none';
+            button.setAttribute('aria-hidden', visible ? 'false' : 'true');
+        }
     }
 
     function iconMarkup(src, label, className) {
@@ -1019,6 +1035,13 @@
         };
     }
 
+    function syncSelectedMethodFromPaymentDetail() {
+        if (!paymentDetail) return;
+        selectedMethod = selectedPaymentMethod(paymentDetail);
+        selectedCurrency = selectedMethod ? selectedMethod.currency : '';
+        selectedNetworkId = selectedMethod ? networkIdentity(selectedMethod) : '';
+    }
+
     function bindDropdownButtons() {
         var currencyButton = $('#currencySelectButton');
         var networkButton = $('#networkSelectButton');
@@ -1075,7 +1098,7 @@
         renderNetworkOptions(networkId);
 
         var candidates = methodsForNetwork(networkId);
-        var nextMethod = preferredMethod && sameNetwork(preferredMethod, networkId) ? preferredMethod : candidates[0];
+        var nextMethod = preferredMethod && candidates.indexOf(preferredMethod) !== -1 ? preferredMethod : candidates[0];
         selectedCurrency = nextMethod ? nextMethod.currency : '';
         renderCurrencyOptions(selectedCurrency);
         selectMethod(nextMethod || null);
@@ -1194,20 +1217,32 @@
             network: selectedMethod.network
         })
             .then(function (data) {
-                paymentDetail = normalizeSelectedPayment(Object.assign({}, selectedMethod, data));
-                if (!paymentDetail.token && paymentDetail.payment_url) {
-                    window.location.href = paymentDetail.payment_url;
+                var nextTradeId = data.trade_id || tradeId;
+                var nextPaymentDetail = normalizeSelectedPayment(Object.assign({}, selectedMethod, data));
+
+                if (!nextPaymentDetail.token && nextPaymentDetail.payment_url) {
+                    window.location.href = nextPaymentDetail.payment_url;
                     return;
                 }
-                if (!paymentDetail.token) {
+                if (!nextPaymentDetail.token) {
                     throw new Error(t('message.createFailed'));
                 }
 
-                tradeId = paymentDetail.trade_id || tradeId;
-                hydrateOrder(Object.assign({}, orderData || {}, data));
-                renderPaymentDetail();
-                setStep('2');
-                restartStatusPolling();
+                tradeId = nextTradeId;
+
+                return apiPost('/api/v1/pay/info', {trade_id: tradeId})
+                    .catch(function () {
+                        return {};
+                    })
+                    .then(function (freshOrder) {
+                        orderData = Object.assign({}, orderData || {}, data, freshOrder);
+                        paymentDetail = normalizeSelectedPayment(Object.assign({}, selectedMethod, nextPaymentDetail, freshOrder));
+                        reselectingPayment = false;
+                        hydrateOrder(orderData);
+                        renderPaymentDetail();
+                        setStep('2');
+                        restartStatusPolling();
+                    });
             })
             .catch(function (error) {
                 showMessage(error.message || t('message.networkError'));
@@ -1217,6 +1252,32 @@
                     button.disabled = false;
                     button.textContent = t('actions.next');
                 }
+            });
+    }
+
+    function returnToMethodSelection(button) {
+        if (!canReselectPayment()) return;
+
+        function showSelectionStep() {
+            reselectingPayment = true;
+            syncSelectedMethodFromPaymentDetail();
+            renderPaymentSelectors();
+            setStep('1');
+        }
+
+        if (methods.length > 0) {
+            showSelectionStep();
+            return;
+        }
+
+        if (button) button.disabled = true;
+        loadMethods()
+            .then(showSelectionStep)
+            .catch(function (error) {
+                showMessage(error.message || t('message.loadFailed'));
+            })
+            .finally(function () {
+                if (button) button.disabled = false;
             });
     }
 
@@ -1456,7 +1517,11 @@
         $all('[data-step-target]').forEach(function (button) {
             button.addEventListener('click', function () {
                 var target = button.dataset.stepTarget || '1';
-                if (target === '2' && !paymentDetail) return;
+                if (target === '2' && (!paymentDetail || reselectingPayment)) return;
+                if (target === '1' && paymentDetail) {
+                    returnToMethodSelection(button);
+                    return;
+                }
                 setStep(target);
             });
         });
@@ -1531,11 +1596,26 @@
 
                 paymentDetail = normalizePaymentFromOrder(data);
                 if (paymentDetail) {
-                    selectedMethod = selectedPaymentMethod(paymentDetail);
-                    selectedCurrency = selectedMethod ? selectedMethod.currency : '';
-                    selectedNetworkId = selectedMethod ? networkIdentity(selectedMethod) : '';
+                    if (canReselectPayment()) {
+                        selectedMethod = null;
+                        selectedCurrency = '';
+                        selectedNetworkId = '';
+                        return loadMethods()
+                            .catch(function (error) {
+                                showMessage(error.message || t('message.loadFailed'));
+                            })
+                            .then(function () {
+                                syncSelectedMethodFromPaymentDetail();
+                                renderPaymentSelectors();
+                                renderPaymentDetail();
+                                setStep('2');
+                                updateReselectControls();
+                            });
+                    }
+                    syncSelectedMethodFromPaymentDetail();
                     renderPaymentDetail();
                     setStep('2');
+                    updateReselectControls();
                     return;
                 }
 

--- a/static/checkout/langge/views/checkout.html
+++ b/static/checkout/langge/views/checkout.html
@@ -233,7 +233,7 @@
                         </div>
 
                         <div class="action-row edge">
-                            <button class="button secondary" type="button" data-step-target="1" data-i18n="actions.back">返回上一步</button>
+                            <button class="button secondary" id="backToMethodButton" type="button" data-step-target="1" data-i18n="actions.back" hidden>返回上一步</button>
                         </div>
                     </section>
                 </div>

--- a/static/checkout/official/assets/css/checkout.css
+++ b/static/checkout/official/assets/css/checkout.css
@@ -423,6 +423,28 @@ body {
     word-break: break-all;
     line-height: 1.5;
 }
+.reselect-btn {
+    width: 100%;
+    align-items: center;
+    justify-content: center;
+    border: 1.5px solid var(--color-border);
+    border-radius: 12px;
+    background: #fff;
+    color: var(--color-text-secondary);
+    font-size: 13px;
+    font-weight: 600;
+    line-height: 1.2;
+    padding: 10px 12px;
+    margin: -6px 0 16px;
+    cursor: pointer;
+    transition: border-color .15s, color .15s, background .15s, transform .15s;
+}
+.reselect-btn:hover {
+    border-color: var(--color-accent);
+    color: var(--color-accent);
+    background: rgba(0, 178, 106, .05);
+}
+.reselect-btn:active { transform: translateY(1px); }
 
 .toast {
     position: fixed;
@@ -621,4 +643,3 @@ body {
 @media (max-width: 360px) {
     .amount-fiat { font-size: 22px; }
 }
-

--- a/static/checkout/official/assets/js/checkout.js
+++ b/static/checkout/official/assets/js/checkout.js
@@ -557,6 +557,18 @@
         });
     }
 
+    function updateReselectButton() {
+        var btn = document.getElementById('reselectPaymentBtn');
+        if (!btn) return;
+        btn.style.display = orderData && orderData.reselect ? 'inline-flex' : 'none';
+        if (!btn.dataset.bound) {
+            btn.dataset.bound = '1';
+            btn.addEventListener('click', function () {
+                showSelection();
+            });
+        }
+    }
+
     function showPayment() {
         document.getElementById('selectionStage').style.display = 'none';
         document.getElementById('paymentStage').style.display = 'block';
@@ -574,6 +586,7 @@
         var addr = document.getElementById('addressLabelQ');
         if (addr) addr.textContent = _t('receivingAddress', '收款地址');
         $('#qrcode').empty().qrcode({ text: d.token || d.address || '', width: 200, height: 200 });
+        updateReselectButton();
         bindHelp('helpBtnQ', d.support_url);
         Payment.initQrPage({
             expired_at: d.expired_at,

--- a/static/checkout/official/assets/locales/en.json
+++ b/static/checkout/official/assets/locales/en.json
@@ -17,6 +17,7 @@
   "networkPrefix": "Network · ",
   "receivingAddress": "Receiving Address",
   "copyAddressTitle": "Copy address",
+  "reselectPayment": "Wrong payment method? Choose again",
   "toastCopied": "Copied",
   "toastAmountCopied": "Amount copied",
   "toastAddressCopied": "Address copied",

--- a/static/checkout/official/assets/locales/zh.json
+++ b/static/checkout/official/assets/locales/zh.json
@@ -17,6 +17,7 @@
   "networkPrefix": "区块网络 · ",
   "receivingAddress": "收款地址",
   "copyAddressTitle": "复制地址",
+  "reselectPayment": "选错了付款方式？返回重选",
   "toastCopied": "已复制",
   "toastAmountCopied": "金额已复制",
   "toastAddressCopied": "地址已复制",

--- a/static/checkout/official/views/checkout.html
+++ b/static/checkout/official/views/checkout.html
@@ -194,6 +194,9 @@
             </div>
             <div class="address-value" id="walletAddress">--</div>
         </div>
+        <button class="reselect-btn" id="reselectPaymentBtn" type="button" style="display:none;" data-i18n="reselectPayment">
+            选错了付款方式？返回重选
+        </button>
     </div>
     <div class="card-footer">
         <div class="footer-powered">

--- a/web/src/views/system/base/base.vue
+++ b/web/src/views/system/base/base.vue
@@ -104,6 +104,7 @@ const getConf = async () => {
         "payment_min_amount",
         "payment_support_url",
         "payment_checkout",
+        "order_trade_type_reselect",
         "payment_timeout",
         "payment_lookback_hour",
         "notifier_params",

--- a/web/src/views/system/base/components/api.vue
+++ b/web/src/views/system/base/components/api.vue
@@ -38,6 +38,14 @@
             <a-input v-model="form.payment_support_url" placeholder="http(s)://your-support-url" allow-clear />
           </a-form-item>
 
+          <a-form-item
+            field="order_trade_type_reselect"
+            label="交易类型重选"
+            extra="用户确认交易类型后，允许其再次重选网络/代币；仅对创建订单接口有效；默认开启"
+          >
+            <a-switch v-model="form.order_trade_type_reselect" />
+          </a-form-item>
+
           <a-form-item>
             <a-space>
               <a-button type="primary" html-type="submit">提交</a-button>
@@ -63,7 +71,8 @@ const form = ref({
   api_auth_token: "",
   api_app_uri: "",
   payment_checkout: "",
-  payment_support_url: ""
+  payment_support_url: "",
+  order_trade_type_reselect: true
 });
 const rules = {};
 const checkoutList = ref<Array<{ label: string; value: string; author: string; desc: string; link: string }>>([]);
@@ -84,6 +93,10 @@ const normalizePaymentCheckout = (value?: string) => {
   return validValues[0] || "";
 };
 
+function resolveOrderTradeTypeReselect(value?: string) {
+  return value ? value === "1" : true;
+}
+
 const syncFormFromConfig = () => {
   if (!data.value) return;
 
@@ -91,6 +104,7 @@ const syncFormFromConfig = () => {
   form.value.api_app_uri = data.value.api_app_uri || "";
   form.value.payment_checkout = normalizePaymentCheckout(data.value.payment_checkout || data.value.payment_template);
   form.value.payment_support_url = data.value.payment_support_url || "";
+  form.value.order_trade_type_reselect = resolveOrderTradeTypeReselect(data.value.order_trade_type_reselect);
 };
 
 // 获取收银台模板列表
@@ -155,6 +169,10 @@ const onSubmit = async ({ errors }: ArcoDesign.ArcoSubmit) => {
     {
       key: "payment_support_url",
       value: form.value.payment_support_url
+    },
+    {
+      key: "order_trade_type_reselect",
+      value: form.value.order_trade_type_reselect ? "1" : "0"
     }
   ]);
 


### PR DESCRIPTION
### 后端：

1. 拆分 create-order 接口创建的订单常量为 `epusdt_order`，用于区分是 `create-transaction` 还是 `create-order`。
2. order 表，增加 `trade_type_reselect ` 字段，用于订单级控制是否允许重选。
3. conf 表，使用 `order_trade_type_reselect` 字段 key 存储全局重选选项开关。
4. create-order 接口，增加 `reselect` boolean 可选参数，用于在订单创建阶段控制是否允许重选，接口回复也显示是否支持 reselect。
5. `/api/v1/pay/info` 接口，增加 `reselect` 响应字段，方便前端控制是否允许重选。
6. 收紧 `/api/v1/pay/methods` 接口，仅限订单为等待支付阶段才能获取数据。
7. 收紧 `/api/v1/pay/update-order` 接口，仅限订单为等待支付才可更新订单。
8. 收紧 `/api/v1/pay/update-order` 接口，显式拒绝过期的订单更新订单。

### 前端管理后台：
1. 增加：解析 `order_trade_type_reselect` 全局重选选项开关，且默认为开启状态。


### 前端收银台：
#### 1. official 模板：
##### 1.1 增加：在卡片底部增加“选错了付款方式？返回重选”按钮，当不可重选时，该按钮不可见。

#### 2. LangGe 模板：
##### 2.1 增加：正确读取 `/api/v1/pay/info` 返回的 `reselect` 参数。
##### 2.2 增加：全局 `[hidden]` css，避免“上一步”的 `.button` 的 `display: inline-flex` 覆盖浏览器默认隐藏样式。
##### 2.2 变更：
  - 订单不允许重选时，不可选“上一步”，即使想办法强制返回上一步也不可选择币种、网络；
  - 订单允许重选，返回上一步可见，点击后重新渲染币种网络列表，用户选择后再次调用 `/api/v1/pay/update-order` 更新币种/网络，`update-order` 成功后会再拉一次 `/api/v1/pay/info`，拿到最新付款详情。
##### 2.3 修复：刷新页面后，如果支持 `reselect`，先清空旧的选择，加载 methods，再用付款信息重新匹配真实 methods，然后渲染下拉框，避免因为旧对象导致下拉列表为空。


### 逻辑：

1. 全局关闭重选时，create-order 创建订单时，仍然可通过传递 bool reselect 参数且为 true，来强制支持重选。
2. 即使 reselect 为真，也仅允许 create-order 订单类型才可走变更付款类型，create-transaction 本身就是指定好的付款类型，不允许变更。
3. 有时候任务未及时处理变更订单状态为过期，此时用户通过 update-order 更新订单可能会传递 order.ExpiredAt 为负值（概率极低），改成拒绝剩余时间小于等于 0 时更新订单，会更稳妥一些。

### 为什么要默认 `reselect` 为 `true` ，让用户默认可变更付款类型？

因为用户可能：
1. 不小心看错了链，比如说将 TON 错误地看成了 TRON、或将 BSC 错以为是 USDT-BEP20；
2. 想支付时，实际钱包里的钱不够支付，导致用户无法再付款（惭愧地说，这种情况我自己也发生过）；
3. 单纯“手残”不小心点错了；最终从而导致用户没有后悔药。

用户无法付款那么他只能去重新下单，create-order 接口是不会重置超时时间的，这样大大降低效率不说，体验也不好。
当时写 update-order 接口的初衷也是为了让用户可变更付款类型。
还有我敢肯定，99% 的 BEpusdt 用户，是不会去改设置里这个选项的，保持默认开启是最好的，实在是不想要，小部分人会自己去关闭。

### 图：

#### 后台
<img width="1081" height="926" alt="screenshot_2026-06-23_22-33-01" src="https://github.com/user-attachments/assets/576b86f7-811a-4110-a199-77758c14735a" />

#### 官方模板 收银台（开启重选时）：

<img width="699" height="913" alt="screenshot_2026-06-23_23-20-22" src="https://github.com/user-attachments/assets/fbe8ccf5-2dde-4fba-a30a-5afb7f63d5d2" />

#### LangGe 模板 收银台（关闭重选时）：

<img width="1727" height="978" alt="screenshot_2026-06-23_22-31-36" src="https://github.com/user-attachments/assets/d4a81912-bbc8-41bf-8bd9-914e7911c685" />