### PR TITLE
feat: static: allow the deployer to use an external checkout theme

### DIFF
--- a/app/router/static.go
+++ b/app/router/static.go
@@ -7,6 +7,7 @@ import (
 	"html/template"
 	"io/fs"
 	"net/http"
+	"os"
 	"path"
 	"strings"
 
@@ -22,8 +23,11 @@ func staticInit(e *gin.Engine) {
 	template.Must(tmpl.ParseFS(static.Secure, "secure/secure.html"))
 	template.Must(tmpl.ParseFS(static.Payment, "payment/views/*.html"))
 
+	checkoutFS, checkoutRoot, checkoutSourceDesc := checkoutSource()
+	log.Info("当前使用", checkoutSourceDesc)
+
 	// 注册收银台模板和静态资源
-	entries, err := fs.ReadDir(static.Checkout, "checkout")
+	entries, err := fs.ReadDir(checkoutFS, checkoutRoot)
 	if err != nil {
 		panic(errors.New(fmt.Sprintf("收银台模板读取异常：%v", err)))
 	}
@@ -34,23 +38,37 @@ func staticInit(e *gin.Engine) {
 		}
 
 		name := entry.Name()
-		dir := path.Join("checkout", name)
-		checkout, err := readCheckoutInfoFromFS(static.Checkout, dir)
+		dir := path.Join(checkoutRoot, name)
+		checkout, err := readCheckoutInfoFromFS(checkoutFS, dir)
 		if err != nil {
 			panic(err)
 		}
 
-		if registerTemplatesFromFS(tmpl, static.Checkout, dir, name) {
+		if registerTemplatesFromFS(tmpl, checkoutFS, dir, name) {
 			model.RegisterCheckout(name, checkout)
 			log.Info("前台收银模板注册成功：", name)
 		}
 
-		registerAssetsFromFS(e, static.Checkout, dir, "/checkout/"+name+"/assets")
+		registerAssetsFromFS(e, checkoutFS, dir, "/checkout/"+name+"/assets")
 	}
 
 	e.SetHTMLTemplate(tmpl)
 	e.StaticFS("/payment/assets", http.FS(subFS(static.Payment, "payment/assets")))
 	e.StaticFS("/secure/assets", http.FS(subFS(static.Secure, "secure/assets")))
+}
+
+func checkoutSource() (fs.FS, string, string) {
+	const externalStaticDir = "static"
+	const checkoutRoot = "checkout"
+	const externalCheckoutDir = externalStaticDir + "/" + checkoutRoot
+
+	if info, err := os.Stat(externalCheckoutDir); err == nil && info.IsDir() {
+		return os.DirFS(externalStaticDir), checkoutRoot, "外部收银台模板目录：" + externalCheckoutDir
+	} else if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return static.Checkout, checkoutRoot, "内嵌收银台模板（外部目录读取失败：" + err.Error() + "）"
+	}
+
+	return static.Checkout, checkoutRoot, "内嵌收银台模板"
 }
 
 func readCheckoutInfoFromFS(src fs.FS, baseDir string) (model.Checkout, error) {


### PR DESCRIPTION
允许使用 BEpusdt 的用户使用外部收银台模板主题，不用去编译 go 二进制。
外部主题优先级比 embedFS 中的主题优先级高，这样可以覆盖内嵌，好处是可以让用户小改一下不用换主题名字。
外部主题路径默认搜索 `pwd` 下的 static/checkout 文件夹。