### PR TITLE
fix: use match_address when locking exclusive wallets

### DIFF
--- a/app/model/order.go
+++ b/app/model/order.go
@@ -420,7 +420,7 @@ func LockTradeAddress(wallets []Wallet, t TradeType) (Wallet, string, error) {
 	status := []int{OrderStatusConfirming, OrderStatusWaiting}
 	for _, w := range wallets {
 		var o Order
-		Db.Where("match_addr = ? and status in (?) and trade_type = ? and address_locked = ?", w.GetMatchAddr(), status, t, true).Order("id desc").Limit(1).Find(&o)
+		Db.Where("match_address = ? and status in (?) and trade_type = ? and address_locked = ?", w.GetMatchAddr(), status, t, true).Order("id desc").Limit(1).Find(&o)
 		if o.ID == 0 {
 			return w, zero, nil
 		}


### PR DESCRIPTION
## Summary
- `LockTradeAddress` queried `bep_order` with column `match_addr` (wallet table name), but the order model column is `match_address`.
- This caused MySQL `Error 1054: Unknown column 'match_addr'` and made exclusive (`address_locked`) address checks always treat addresses as free.

## Test plan
- [ ] Create a zero-amount / address-locked order and confirm no `Unknown column 'match_addr'` in logs
- [ ] Create a second exclusive order against the same wallet+trade_type while the first is waiting/confirming and confirm it returns「暂无可用钱包地址」
- [ ] Shared (non-locked) amount-based orders still allocate addresses as before