### PR TITLE
fix: keep block scanner awake while orders await confirmation

### DIFF
--- a/app/task/transfer.go
+++ b/app/task/transfer.go
@@ -260,7 +260,7 @@ func markFinalConfirmed(o model.Order) {
 }
 
 func receivableOrderStatuses() []int {
-	return []int{model.OrderStatusWaiting, model.OrderStatusExpired}
+	return []int{model.OrderStatusWaiting, model.OrderStatusExpired, model.OrderStatusConfirming}
 }
 
 func getReceivableOrders() map[string][]model.Order {


### PR DESCRIPTION
## Problem

On EVM chains an order can get stuck in `OrderStatusConfirming` forever and never fire its `notify` — the payment is on-chain and has far more than enough confirmations, but the merchant is never credited. It happens when `block_offset_confirm` is enabled and the confirming order is the only pending order (typical for low-traffic merchants).

## Root cause

Block scanning is demand-driven. `syncBreak()` halts the forward scan once `hasLookbackOrders()` finds no "receivable" orders, and `receivableOrderStatuses()` only returned `{Waiting, Expired}`:

```go
func receivableOrderStatuses() []int {
	return []int{model.OrderStatusWaiting, model.OrderStatusExpired}
}
```

When an order transitions `Waiting → Confirming` and it is the only pending order, `hasLookbackOrders()` becomes false, the forward scan stops, and the in-memory `chainBlockNum` freezes.

With `block_offset_confirm` enabled, `tradeConfirmHandle()` gates confirmation on `chainBlockNum - RefBlockNum >= ConfirmedOffset` (e.g. 40 on Polygon). A frozen `chainBlockNum` therefore never reaches the threshold, so the order stays `Confirming` indefinitely — no notify, merchant never credited. It does not recover across restarts, because with no waiting/expired order the scanner correctly stays idle.

(With `block_offset_confirm` disabled the confirmation gate is skipped, so this only bites deployments that enable confirmations on an EVM chain — which is exactly the safe choice against reorgs.)

## Fix

Include `OrderStatusConfirming` in `receivableOrderStatuses()` so the scanner keeps advancing while any order is awaiting confirmation.

## Validation

Reproduced on Polygon (`block_offset_confirm=1`, `ConfirmedOffset=40`): a lone confirming order backed by a real, on-chain-confirmed USDT transfer (500+ confirmations) stayed in `Confirming` forever on an unpatched build — the scanner was idle and `chainBlockNum` was frozen. With this change the scanner stays awake, `chainBlockNum` advances, `tradeConfirmHandle()` promotes the order to success, and the notify fires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
