### PR TITLE
修复多链漏单：补充支付回查并改进 Solana/BSC 区块扫描

### DIFF
--- a/app/handler/epusdt/epusdt.go
+++ b/app/handler/epusdt/epusdt.go
@@ -3,15 +3,18 @@ package epusdt
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"math"
+	"strings"
 	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/shopspring/decimal"
 	"github.com/v03413/bepusdt/app/log"
 	"github.com/v03413/bepusdt/app/model"
+	"github.com/v03413/bepusdt/app/task"
 	"github.com/v03413/bepusdt/app/utils"
 )
 
@@ -63,6 +66,13 @@ type methodsReq struct {
 	TradeID  string `json:"trade_id" binding:"required"`
 	Currency string `json:"currency"`
 }
+
+type verifyTransactionReq struct {
+	TradeID string `json:"trade_id" binding:"required"`
+	TxHash  string `json:"tx_hash" binding:"required"`
+}
+
+var verifyAndClaimSubmittedPayment = task.VerifyAndClaimSubmittedPayment
 
 // tradeTypeReselect 返回本次 create-order 是否允许确认交易类型后再次重选；未传 reselect 时使用后台全局配置。
 func (r createOrderReq) tradeTypeReselect() bool {
@@ -394,24 +404,101 @@ func (Epusdt) Info(ctx *gin.Context) {
 		return
 	}
 
+	var returnURL string
+	if order.Status == model.OrderStatusSuccess {
+		returnURL = order.ReturnUrl
+		if order.ApiType == model.OrderApiTypeEpay {
+			returnURL = fmt.Sprintf("%s?%s", returnURL, order.BuildNotifyParams())
+		}
+	}
+	progress := model.GetChainProgress(order)
+
 	ctx.JSON(200, respSuccJson(gin.H{
-		"network":       order.Network(),                     // 网络信息
-		"trade_id":      order.TradeId,                       // 交易编号
-		"order_id":      order.OrderId,                       // 商户订单
-		"trade_type":    order.TradeType,                     // 交易类型
-		"status":        order.Status,                        // 订单状态
-		"money":         order.Money,                         // 订单金额
-		"actual_amount": order.Amount,                        // 实付数额
-		"token":         order.Address,                       // 收款地址
-		"fiat":          order.Fiat,                          // 法币类型
-		"name":          order.Name,                          // 商品名称
-		"expired_at":    order.ExpiredAt.Unix(),              // 截止时间
-		"created_at":    order.CreatedAt.Time().Unix(),       // 创建时间
-		"trade_url":     order.GetTxUrl(),                    // 链上详情
-		"support_url":   model.GetC(model.PaymentSupportUrl), // 客服链接
-		"redirect_url":  order.RedirectUrl(),                 // 跳转地址
-		"reselect":      order.CanReselectPayment(),          // 是否允许确认交易类型后重选
+		"network":                order.Network(),
+		"trade_id":               order.TradeId,
+		"order_id":               order.OrderId,
+		"trade_type":             order.TradeType,
+		"status":                 order.Status,
+		"money":                  order.Money,
+		"actual_amount":          order.Amount,
+		"token":                  order.Address,
+		"fiat":                   order.Fiat,
+		"name":                   order.Name,
+		"expired_at":             order.ExpiredAt.Unix(),
+		"created_at":             order.CreatedAt.Time().Unix(),
+		"trade_url":              order.GetTxUrl(),
+		"support_url":            model.GetC(model.PaymentSupportUrl),
+		"redirect_url":           order.RedirectUrl(),
+		"return_url":             returnURL,
+		"trade_hash":             order.RefHash,
+		"confirmations":          progress.Current,
+		"required_confirmations": progress.Required,
+		"reselect":               order.CanReselectPayment(),
 	}))
+}
+
+// VerifyTransaction lets a payer submit an on-chain transaction hash as a
+// verification clue. The task layer independently fetches and validates the
+// transaction before this endpoint can move an order into confirmation.
+func (Epusdt) VerifyTransaction(ctx *gin.Context) {
+	var req verifyTransactionReq
+	if err := ctx.ShouldBindJSON(&req); err != nil {
+		ctx.JSON(200, respFailJson("invalid transaction verification request"))
+		return
+	}
+
+	order, ok := model.GetTradeOrder(req.TradeID)
+	if !ok {
+		ctx.JSON(200, respFailJson("order not found"))
+		return
+	}
+
+	if (order.Status == model.OrderStatusConfirming || order.Status == model.OrderStatusSuccess) &&
+		order.RefHash != "" && strings.EqualFold(order.RefHash, strings.TrimSpace(req.TxHash)) {
+		ctx.JSON(200, respSuccJson(gin.H{
+			"trade_id":   order.TradeId,
+			"status":     order.Status,
+			"trade_hash": order.RefHash,
+			"idempotent": true,
+		}))
+		return
+	}
+	if order.Status != model.OrderStatusWaiting && order.Status != model.OrderStatusExpired {
+		ctx.JSON(200, respFailJson("the current order status does not allow transaction verification"))
+		return
+	}
+
+	_, err := verifyAndClaimSubmittedPayment(ctx.Request.Context(), &order, req.TxHash)
+	if err != nil {
+		ctx.JSON(200, respFailJson(submittedPaymentErrorMessage(err)))
+		return
+	}
+
+	ctx.JSON(200, respSuccJson(gin.H{
+		"trade_id":   order.TradeId,
+		"status":     order.Status,
+		"trade_hash": order.RefHash,
+	}))
+}
+
+func submittedPaymentErrorMessage(err error) string {
+	switch {
+	case errors.Is(err, task.ErrInvalidSubmittedPaymentHash):
+		return "invalid transaction hash"
+	case errors.Is(err, task.ErrUnsupportedSubmittedPayment):
+		return "transaction hash verification is not available for this payment network"
+	case errors.Is(err, task.ErrSubmittedPaymentNotFound):
+		return "transaction was not found or has not been confirmed on-chain yet"
+	case errors.Is(err, task.ErrSubmittedPaymentDoesNotMatch):
+		return "the submitted transaction does not match this order"
+	case errors.Is(err, model.ErrPaymentHashAlreadyClaimed):
+		return "this transaction has already been used for another order"
+	case errors.Is(err, model.ErrOrderNoLongerReceivable):
+		return "the current order status does not allow transaction verification"
+	default:
+		log.Warn(fmt.Sprintf("verify submitted transaction failed: %v", err))
+		return "unable to verify this transaction right now; please try again"
+	}
 }
 
 func (Epusdt) SignVerify(ctx *gin.Context) {

--- a/app/handler/epusdt/payment_verification_test.go
+++ b/app/handler/epusdt/payment_verification_test.go
@@ -1,0 +1,89 @@
+package epusdt
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/shopspring/decimal"
+	"github.com/v03413/bepusdt/app/model"
+)
+
+func TestVerifyTransactionMarksOrderConfirming(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	if err := model.Init(filepath.Join(t.TempDir(), "bepusdt.db"), "", ""); err != nil {
+		t.Fatalf("initialize test database: %v", err)
+	}
+
+	now := time.Now().UTC()
+	order := model.Order{
+		OrderId:      "merchant-order",
+		TradeId:      "local-order",
+		TradeType:    model.UsdtTrc20,
+		Fiat:         model.CNY,
+		Crypto:       model.USDT,
+		Rate:         "7.00",
+		Amount:       "65.94",
+		Money:        "461.58",
+		Address:      "TKNUJShSXfCDii9bxdguPwgZsKXG6rBLC6",
+		MatchAddress: "TKNUJShSXfCDii9bxdguPwgZsKXG6rBLC6",
+		Status:       model.OrderStatusWaiting,
+		ApiType:      model.OrderApiTypeEpusdt,
+		ExpiredAt:    now.Add(10 * time.Minute),
+		ConfirmedAt:  &now,
+		AutoTimeAt:   model.AutoTimeAt{CreatedAt: (*model.Datetime)(&now), UpdatedAt: (*model.Datetime)(&now)},
+	}
+	if err := model.Db.Create(&order).Error; err != nil {
+		t.Fatalf("seed order: %v", err)
+	}
+
+	originalVerifier := verifyAndClaimSubmittedPayment
+	verifyAndClaimSubmittedPayment = func(_ context.Context, o *model.Order, hash string) (bool, error) {
+		return model.ClaimPaymentConfirmation(o, model.PaymentConfirmation{
+			BlockNum: 100,
+			From:     "TJ5usJLLwjwn7Pw3TPbdzreG7dvgKzfQ5y",
+			Hash:     hash,
+			At:       now.Add(time.Second),
+			Amount:   decimal.RequireFromString("65.94"),
+		})
+	}
+	t.Cleanup(func() { verifyAndClaimSubmittedPayment = originalVerifier })
+
+	w := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(w)
+	ctx.Request = httptest.NewRequest(http.MethodPost, "/api/v1/pay/verify-transaction", bytes.NewBufferString(`{"trade_id":"local-order","tx_hash":"303245e65da6dca3e7aed8dc5386cd0cbbc7f67e4c21ff4ee0d9330055a41983"}`))
+	ctx.Request.Header.Set("Content-Type", "application/json")
+
+	new(Epusdt).VerifyTransaction(ctx)
+
+	var response struct {
+		StatusCode int `json:"status_code"`
+		Data       struct {
+			Status    int    `json:"status"`
+			TradeHash string `json:"trade_hash"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if response.StatusCode != http.StatusOK || response.Data.Status != model.OrderStatusConfirming {
+		t.Fatalf("unexpected response: %s", w.Body.String())
+	}
+	if response.Data.TradeHash == "" {
+		t.Fatalf("response should return the verified transaction hash: %s", w.Body.String())
+	}
+
+	var refreshed model.Order
+	if err := model.Db.First(&refreshed, order.ID).Error; err != nil {
+		t.Fatalf("load updated order: %v", err)
+	}
+	if refreshed.Status != model.OrderStatusConfirming || refreshed.RefHash != response.Data.TradeHash {
+		t.Fatalf("order was not marked confirming: %+v", refreshed)
+	}
+}

--- a/app/model/conf.go
+++ b/app/model/conf.go
@@ -29,15 +29,15 @@ var defaultConf = map[ConfKey]string{
 	PaymentMinAmount:        "0.01",
 	PaymentMaxAmount:        "99999",
 	RpcEndpointTron:         "grpc.trongrid.io:50051",
-	RpcEndpointBsc:          "https://binance-smart-chain-public.nodies.app/",
-	RpcEndpointSolana:       "https://solana-rpc.publicnode.com/",
-	RpcEndpointXlayer:       "https://xlayerrpc.okx.com/",
-	RpcEndpointPolygon:      "https://polygon-public.nodies.app/",
-	RpcEndpointArbitrum:     "https://arb1.arbitrum.io/rpc",
-	RpcEndpointEthereum:     "https://ethereum-public.nodies.app/",
-	RpcEndpointBase:         "https://base-public.nodies.app/",
-	RpcEndpointAptos:        "https://aptos-rest.publicnode.com/",
-	RpcEndpointPlasma:       "https://rpc.plasma.to/",
+	RpcEndpointBsc:          "https://bsc-rpc.publicnode.com,https://bsc-dataseed.binance.org,https://binance-smart-chain-public.nodies.app/",
+	RpcEndpointSolana:       "https://solana-rpc.publicnode.com,https://api.mainnet-beta.solana.com",
+	RpcEndpointXlayer:       "https://xlayerrpc.okx.com/,https://rpc.xlayer.tech",
+	RpcEndpointPolygon:      "https://polygon-bor-rpc.publicnode.com,https://polygon-public.nodies.app/,https://polygon.drpc.org",
+	RpcEndpointArbitrum:     "https://arb1.arbitrum.io/rpc,https://arbitrum-one-rpc.publicnode.com,https://arbitrum.drpc.org",
+	RpcEndpointEthereum:     "https://ethereum-rpc.publicnode.com,https://eth.drpc.org,https://rpc.flashbots.net",
+	RpcEndpointBase:         "https://mainnet.base.org,https://base-rpc.publicnode.com,https://base.drpc.org",
+	RpcEndpointAptos:        "https://fullnode.mainnet.aptoslabs.com/,https://aptos-rest.publicnode.com/",
+	RpcEndpointPlasma:       "https://rpc.plasma.to/,https://plasma.drpc.org",
 	RpcGlobalConfigUrlTon:   "https://ton.org/global-config.json",
 	NotifyMaxRetry:          "10",
 	BlockHeightMaxDiff:      "1000",
@@ -76,12 +76,14 @@ func SetK(k ConfKey, v string) {
 			return err2
 		}
 
-		defer RefreshC()
-
 		return nil
 	}); err != nil {
 		_, _ = fmt.Fprintln(os.Stderr, fmt.Sprintf("设置配置项 %s 错误：%s", k, err.Error()))
+
+		return
 	}
+
+	RefreshC()
 }
 
 func GetK(k ConfKey) string {

--- a/app/model/endpoint.go
+++ b/app/model/endpoint.go
@@ -1,0 +1,67 @@
+package model
+
+import (
+	"regexp"
+	"strings"
+	"sync"
+)
+
+var endpointMu sync.Mutex
+var endpointIndexes = make(map[Network]int)
+
+var endpointSeparators = regexp.MustCompile(`[,\n;\s]+`)
+
+func EndpointCandidates(net Network) []string {
+	endpointKey, ok := networkEndpointMap[net]
+	if !ok {
+		return nil
+	}
+
+	raw := GetC(endpointKey)
+	if raw == "" {
+		raw = GetK(endpointKey)
+	}
+
+	return parseEndpoints(raw)
+}
+
+func ReportEndpointFailure(net Network, failed string) string {
+	endpoints := EndpointCandidates(net)
+	if len(endpoints) == 0 {
+		return ""
+	}
+	if len(endpoints) == 1 {
+		return endpoints[0]
+	}
+
+	endpointMu.Lock()
+	defer endpointMu.Unlock()
+
+	index := endpointIndexes[net]
+	if index < 0 || index >= len(endpoints) || endpoints[index] == failed {
+		index = (index + 1) % len(endpoints)
+		endpointIndexes[net] = index
+	}
+
+	return endpoints[index]
+}
+
+func parseEndpoints(raw string) []string {
+	fields := endpointSeparators.Split(strings.TrimSpace(raw), -1)
+	endpoints := make([]string, 0, len(fields))
+	seen := make(map[string]struct{}, len(fields))
+	for _, field := range fields {
+		field = strings.TrimSpace(field)
+		if field == "" {
+			continue
+		}
+		if _, ok := seen[field]; ok {
+			continue
+		}
+
+		seen[field] = struct{}{}
+		endpoints = append(endpoints, field)
+	}
+
+	return endpoints
+}

--- a/app/model/endpoint_test.go
+++ b/app/model/endpoint_test.go
@@ -1,0 +1,82 @@
+package model
+
+import (
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/v03413/bepusdt/app/conf"
+)
+
+func resetEndpointStateForTest() {
+	confCache.Range(func(key, value any) bool {
+		confCache.Delete(key)
+		return true
+	})
+	endpointMu.Lock()
+	defer endpointMu.Unlock()
+	endpointIndexes = make(map[Network]int)
+}
+
+func TestEndpointCandidatesParsesSingleAndMultipleAddresses(t *testing.T) {
+	resetEndpointStateForTest()
+
+	confCache.Store(RpcEndpointArbitrum, " https://one.example/rpc \nhttps://two.example/rpc, https://three.example/rpc;;")
+
+	got := EndpointCandidates(conf.Arbitrum)
+	want := []string{
+		"https://one.example/rpc",
+		"https://two.example/rpc",
+		"https://three.example/rpc",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("expected candidates %+v, got %+v", want, got)
+	}
+
+	if got := Endpoint(conf.Arbitrum); got != want[0] {
+		t.Fatalf("expected first endpoint %q, got %q", want[0], got)
+	}
+}
+
+func TestReportEndpointFailureRotatesOnlyFailedNetwork(t *testing.T) {
+	resetEndpointStateForTest()
+
+	confCache.Store(RpcEndpointArbitrum, "https://arb-one.example\nhttps://arb-two.example")
+	confCache.Store(RpcEndpointBsc, "https://bsc-one.example\nhttps://bsc-two.example")
+
+	if got := Endpoint(conf.Arbitrum); got != "https://arb-one.example" {
+		t.Fatalf("expected first arbitrum endpoint, got %q", got)
+	}
+
+	next := ReportEndpointFailure(conf.Arbitrum, "https://arb-one.example")
+	if next != "https://arb-two.example" {
+		t.Fatalf("expected arbitrum to rotate to second endpoint, got %q", next)
+	}
+	if got := Endpoint(conf.Arbitrum); got != "https://arb-two.example" {
+		t.Fatalf("expected active arbitrum endpoint to remain second endpoint, got %q", got)
+	}
+	if got := Endpoint(conf.Bsc); got != "https://bsc-one.example" {
+		t.Fatalf("expected bsc endpoint to be unaffected, got %q", got)
+	}
+
+	ReportEndpointFailure(conf.Arbitrum, "https://arb-two.example")
+	if got := Endpoint(conf.Arbitrum); got != "https://arb-one.example" {
+		t.Fatalf("expected arbitrum endpoint to wrap around, got %q", got)
+	}
+}
+
+func TestSetKRefreshesEndpointCacheAfterCommit(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "endpoint-cache.db")
+	if err := Init(dbPath, "", ""); err != nil {
+		t.Fatalf("init test db: %v", err)
+	}
+	t.Cleanup(Close)
+
+	SetK(RpcEndpointArbitrum, "https://arb-one.example,https://arb-two.example")
+
+	got := EndpointCandidates(conf.Arbitrum)
+	want := []string{"https://arb-one.example", "https://arb-two.example"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("expected candidates %+v, got %+v", want, got)
+	}
+}

--- a/app/model/model.go
+++ b/app/model/model.go
@@ -25,6 +25,8 @@ type AutoTimeAt struct {
 }
 
 func Init(path, mysql, postgres string) error {
+	resetRuntimeState()
+
 	if postgres != "" {
 		return initPostgres(postgres)
 	}
@@ -33,6 +35,21 @@ func Init(path, mysql, postgres string) error {
 	}
 
 	return initSqlite(path)
+}
+
+func resetRuntimeState() {
+	confCache.Range(func(key, value any) bool {
+		confCache.Delete(key)
+		return true
+	})
+	chainProgressState.Range(func(key, value any) bool {
+		chainProgressState.Delete(key)
+		return true
+	})
+
+	endpointMu.Lock()
+	endpointIndexes = make(map[Network]int)
+	endpointMu.Unlock()
 }
 
 func initSqlite(path string) error {
@@ -166,7 +183,7 @@ func initPostgres(dsn string) error {
 }
 
 func AutoMigrate() error {
-	return Db.AutoMigrate(&Wallet{}, &Order{}, &NotifyRecord{}, &Conf{}, &Rate{})
+	return Db.AutoMigrate(&Wallet{}, &Order{}, &PaymentHashClaim{}, &NotifyRecord{}, &Conf{}, &Rate{})
 }
 
 func Close() {

--- a/app/model/payment_claim.go
+++ b/app/model/payment_claim.go
@@ -1,0 +1,131 @@
+package model
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/shopspring/decimal"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+var (
+	// ErrPaymentHashAlreadyClaimed means that the same on-chain transaction has
+	// already been associated with a different order.
+	ErrPaymentHashAlreadyClaimed = errors.New("payment hash is already claimed by another order")
+	// ErrOrderNoLongerReceivable means that an order cannot accept a new payment.
+	ErrOrderNoLongerReceivable = errors.New("order is no longer receivable")
+)
+
+// PaymentHashClaim is a durable, cross-process uniqueness guard. A payment
+// transaction may only be associated with one local order.
+type PaymentHashClaim struct {
+	Hash    string `gorm:"column:hash;type:varchar(128);primaryKey;not null" json:"hash"`
+	OrderID int64  `gorm:"column:order_id;not null;index" json:"order_id"`
+	AutoTimeAt
+}
+
+func (PaymentHashClaim) TableName() string {
+	return "bep_payment_hash_claim"
+}
+
+type PaymentConfirmation struct {
+	BlockNum int
+	From     string
+	Hash     string
+	At       time.Time
+	Amount   decimal.Decimal
+}
+
+// ClaimPaymentConfirmation atomically reserves a transaction hash and moves a
+// waiting (or lookback-expired) order into the existing confirming workflow.
+// Repeating a successful claim for the same order is intentionally idempotent.
+func ClaimPaymentConfirmation(order *Order, payment PaymentConfirmation) (alreadyClaimed bool, err error) {
+	if order == nil || order.ID == 0 {
+		return false, fmt.Errorf("claim payment confirmation: order is required")
+	}
+
+	originalHash := strings.TrimSpace(payment.Hash)
+	if originalHash == "" {
+		return false, fmt.Errorf("claim payment confirmation: transaction hash is required")
+	}
+	// Keep Solana's case-sensitive Base58 signature exact both on the order and
+	// in the uniqueness claim. Hex transaction identifiers on the other chains
+	// remain normalized for migration compatibility.
+	claimHash := originalHash
+	trade, isKnownTrade := registry[order.TradeType]
+	isSolana := isKnownTrade && trade.Network == Network("solana")
+	if !isSolana {
+		claimHash = strings.ToLower(originalHash)
+	}
+
+	var updated Order
+	err = Db.Transaction(func(tx *gorm.DB) error {
+		if err := tx.Where("id = ?", order.ID).First(&updated).Error; err != nil {
+			return err
+		}
+
+		if updated.RefHash != "" && strings.EqualFold(updated.RefHash, originalHash) &&
+			(updated.Status == OrderStatusConfirming || updated.Status == OrderStatusSuccess) {
+			alreadyClaimed = true
+			return nil
+		}
+		if updated.Status != OrderStatusWaiting && updated.Status != OrderStatusExpired {
+			return ErrOrderNoLongerReceivable
+		}
+		// Records created before payment-hash claims were introduced do not have
+		// a claim row. Check the order table as a migration-safe fallback before
+		// reserving this hash for a new order.
+		var legacyOwner Order
+		legacyQuery := "LOWER(ref_hash) = ? AND id <> ?"
+		if isSolana {
+			legacyQuery = "ref_hash = ? AND id <> ?"
+		}
+		legacyLookup := tx.Where(legacyQuery, claimHash, updated.ID).First(&legacyOwner).Error
+		if legacyLookup == nil {
+			return ErrPaymentHashAlreadyClaimed
+		}
+		if legacyLookup != nil && !errors.Is(legacyLookup, gorm.ErrRecordNotFound) {
+			return legacyLookup
+		}
+
+		claim := PaymentHashClaim{Hash: claimHash, OrderID: updated.ID}
+		create := tx.Clauses(clause.OnConflict{DoNothing: true}).Create(&claim)
+		if create.Error != nil {
+			return create.Error
+		}
+		if create.RowsAffected == 0 {
+			var existing PaymentHashClaim
+			lookupErr := tx.Where("hash = ?", claimHash).First(&existing).Error
+			if lookupErr == nil && existing.OrderID != updated.ID {
+				return ErrPaymentHashAlreadyClaimed
+			}
+			if lookupErr == nil && existing.OrderID == updated.ID && strings.EqualFold(updated.RefHash, originalHash) {
+				alreadyClaimed = true
+				return nil
+			}
+			return lookupErr
+		}
+
+		updated.FromAddress = payment.From
+		updated.ConfirmedAt = &payment.At
+		updated.RefHash = originalHash
+		updated.RefBlockNum = payment.BlockNum
+		updated.Status = OrderStatusConfirming
+		if updated.AddressLocked {
+			rate, _ := decimal.NewFromString(updated.Rate)
+			updated.Amount = payment.Amount.String()
+			updated.Money = rate.Mul(payment.Amount).String()
+		}
+
+		return tx.Save(&updated).Error
+	})
+	if err != nil {
+		return false, err
+	}
+
+	*order = updated
+	return alreadyClaimed, nil
+}

--- a/app/model/payment_claim_test.go
+++ b/app/model/payment_claim_test.go
@@ -1,0 +1,135 @@
+package model
+
+import (
+	"errors"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/shopspring/decimal"
+)
+
+func TestClaimPaymentConfirmationPreventsHashReuseAndIsIdempotent(t *testing.T) {
+	if err := Init(filepath.Join(t.TempDir(), "bepusdt.db"), "", ""); err != nil {
+		t.Fatalf("initialize test database: %v", err)
+	}
+
+	now := time.Now().UTC()
+	first := newPaymentClaimTestOrder("payment-claim-first", now)
+	second := newPaymentClaimTestOrder("payment-claim-second", now)
+	if err := Db.Create(&first).Error; err != nil {
+		t.Fatalf("create first order: %v", err)
+	}
+	if err := Db.Create(&second).Error; err != nil {
+		t.Fatalf("create second order: %v", err)
+	}
+
+	payment := PaymentConfirmation{
+		BlockNum: 100,
+		From:     "TJ5usJLLwjwn7Pw3TPbdzreG7dvgKzfQ5y",
+		Hash:     "303245E65DA6DCA3E7AED8DC5386CD0CBBC7F67E4C21FF4EE0D9330055A41983",
+		At:       now.Add(time.Second),
+		Amount:   decimal.RequireFromString("65.94"),
+	}
+
+	already, err := ClaimPaymentConfirmation(&first, payment)
+	if err != nil || already {
+		t.Fatalf("first claim = already:%t err:%v, want new successful claim", already, err)
+	}
+	if first.Status != OrderStatusConfirming {
+		t.Fatalf("first order status = %d, want confirming", first.Status)
+	}
+
+	already, err = ClaimPaymentConfirmation(&first, payment)
+	if err != nil || !already {
+		t.Fatalf("same order repeat = already:%t err:%v, want idempotent success", already, err)
+	}
+
+	if _, err := ClaimPaymentConfirmation(&second, payment); !errors.Is(err, ErrPaymentHashAlreadyClaimed) {
+		t.Fatalf("claiming same hash for second order error = %v, want ErrPaymentHashAlreadyClaimed", err)
+	}
+}
+
+func TestClaimPaymentConfirmationProtectsLegacyOrderHash(t *testing.T) {
+	if err := Init(filepath.Join(t.TempDir(), "bepusdt.db"), "", ""); err != nil {
+		t.Fatalf("initialize test database: %v", err)
+	}
+
+	now := time.Now().UTC()
+	legacy := newPaymentClaimTestOrder("legacy-payment-claim", now)
+	legacy.Status = OrderStatusConfirming
+	legacy.RefHash = "303245e65da6dca3e7aed8dc5386cd0cbbc7f67e4c21ff4ee0d9330055a41983"
+	if err := Db.Create(&legacy).Error; err != nil {
+		t.Fatalf("create legacy order: %v", err)
+	}
+
+	newOrder := newPaymentClaimTestOrder("new-payment-claim", now)
+	if err := Db.Create(&newOrder).Error; err != nil {
+		t.Fatalf("create new order: %v", err)
+	}
+	_, err := ClaimPaymentConfirmation(&newOrder, PaymentConfirmation{
+		BlockNum: 101,
+		From:     "TJ5usJLLwjwn7Pw3TPbdzreG7dvgKzfQ5y",
+		Hash:     legacy.RefHash,
+		At:       now.Add(time.Second),
+		Amount:   decimal.RequireFromString("65.94"),
+	})
+	if !errors.Is(err, ErrPaymentHashAlreadyClaimed) {
+		t.Fatalf("legacy hash reuse error = %v, want ErrPaymentHashAlreadyClaimed", err)
+	}
+}
+
+func TestClaimPaymentConfirmationPreservesCaseSensitiveSolanaSignature(t *testing.T) {
+	if err := Init(filepath.Join(t.TempDir(), "bepusdt.db"), "", ""); err != nil {
+		t.Fatalf("initialize test database: %v", err)
+	}
+
+	now := time.Now().UTC()
+	order := newPaymentClaimTestOrder("solana-payment-claim", now)
+	order.TradeType = UsdtSolana
+	if err := Db.Create(&order).Error; err != nil {
+		t.Fatalf("create order: %v", err)
+	}
+
+	const signature = "5GTnZsNBcpPxBb2fEA5u2SwaNVry97ouHsa5oFKKVNEt4Da8YzakDTky6byNLGZDQdLrx9sDXeNr7XYDgNDiSJJQ"
+	_, err := ClaimPaymentConfirmation(&order, PaymentConfirmation{
+		BlockNum: 435577393,
+		From:     "H1NwZnujLy6q2q9Mj813xCMSzkmYE6p6PzyC2zswJSmK",
+		Hash:     signature,
+		At:       time.Unix(1785171892, 0),
+		Amount:   decimal.RequireFromString("1.32"),
+	})
+	if err != nil {
+		t.Fatalf("claim Solana payment: %v", err)
+	}
+	if order.RefHash != signature {
+		t.Fatalf("stored Solana signature = %q, want original %q", order.RefHash, signature)
+	}
+	var claim PaymentHashClaim
+	if err := Db.Where("order_id = ?", order.ID).First(&claim).Error; err != nil {
+		t.Fatalf("load Solana payment claim: %v", err)
+	}
+	if claim.Hash != signature {
+		t.Fatalf("Solana claim key = %q, want case-sensitive signature %q", claim.Hash, signature)
+	}
+}
+
+func newPaymentClaimTestOrder(tradeID string, now time.Time) Order {
+	return Order{
+		OrderId:      tradeID,
+		TradeId:      tradeID,
+		TradeType:    UsdtTrc20,
+		Fiat:         CNY,
+		Crypto:       USDT,
+		Rate:         "7.00",
+		Amount:       "65.94",
+		Money:        "461.58",
+		Address:      "TKNUJShSXfCDii9bxdguPwgZsKXG6rBLC6",
+		MatchAddress: "TKNUJShSXfCDii9bxdguPwgZsKXG6rBLC6",
+		Status:       OrderStatusWaiting,
+		ApiType:      OrderApiTypeEpusdt,
+		ExpiredAt:    now.Add(10 * time.Minute),
+		ConfirmedAt:  &now,
+		AutoTimeAt:   AutoTimeAt{CreatedAt: (*Datetime)(&now), UpdatedAt: (*Datetime)(&now)},
+	}
+}

--- a/app/model/payment_progress.go
+++ b/app/model/payment_progress.go
@@ -1,0 +1,82 @@
+package model
+
+import (
+	"sync"
+
+	"github.com/spf13/cast"
+)
+
+type PaymentProgress struct {
+	Current  int `json:"current"`
+	Required int `json:"required"`
+}
+
+var chainProgressState sync.Map
+
+func SetChainProgress(network Network, height int) {
+	chainProgressState.Store(network, height)
+}
+
+func GetChainProgress(order Order) PaymentProgress {
+	progress := PaymentProgress{}
+	if order.Status != OrderStatusConfirming {
+		return progress
+	}
+
+	conf, ok := registry[order.TradeType]
+	if !ok {
+		return progress
+	}
+
+	required := getRequiredConfirmations(conf.Network)
+	if required <= 0 {
+		progress.Required = 1
+		progress.Current = 1
+		return progress
+	}
+
+	progress.Required = required
+
+	height, ok := chainProgressState.Load(conf.Network)
+	if !ok {
+		return progress
+	}
+
+	current := cast.ToInt(height) - order.RefBlockNum
+	if current < 0 {
+		current = 0
+	}
+	if current > required {
+		current = required
+	}
+
+	progress.Current = current
+	return progress
+}
+
+func getRequiredConfirmations(network Network) int {
+	switch network {
+	case "tron":
+		return 30
+	case "bsc":
+		return 15
+	case "ethereum":
+		return 12
+	case "polygon":
+		return 40
+	case "arbitrum":
+		return 40
+	case "base":
+		return 40
+	case "xlayer":
+		return 12
+	case "plasma":
+		return 40
+	case "solana":
+		return 60
+	case "aptos":
+		return 1000
+	default:
+		return 0
+	}
+}

--- a/app/model/payment_progress_test.go
+++ b/app/model/payment_progress_test.go
@@ -1,0 +1,36 @@
+package model
+
+import (
+	"testing"
+
+	"github.com/v03413/bepusdt/app/conf"
+)
+
+func TestGetChainProgress(t *testing.T) {
+	SetChainProgress(conf.Bsc, 120)
+
+	progress := GetChainProgress(Order{
+		TradeType:   UsdtBep20,
+		Status:      OrderStatusConfirming,
+		RefBlockNum: 100,
+	})
+
+	if progress.Current != 15 {
+		t.Fatalf("expected capped current confirmations 15, got %d", progress.Current)
+	}
+	if progress.Required != 15 {
+		t.Fatalf("expected required confirmations 15, got %d", progress.Required)
+	}
+}
+
+func TestGetChainProgressWaitingOrder(t *testing.T) {
+	progress := GetChainProgress(Order{
+		TradeType:   UsdtBep20,
+		Status:      OrderStatusWaiting,
+		RefBlockNum: 100,
+	})
+
+	if progress.Current != 0 || progress.Required != 0 {
+		t.Fatalf("expected zero progress for waiting order, got %+v", progress)
+	}
+}

--- a/app/model/registry.go
+++ b/app/model/registry.go
@@ -418,10 +418,21 @@ func IsAmountValid(t TradeType, d decimal.Decimal) bool {
 }
 
 func Endpoint(net Network) string {
-	if endpointKey, ok := networkEndpointMap[net]; ok {
-		return GetC(endpointKey)
+	endpoints := EndpointCandidates(net)
+	if len(endpoints) == 0 {
+		return ""
 	}
-	return ""
+
+	endpointMu.Lock()
+	defer endpointMu.Unlock()
+
+	index := endpointIndexes[net]
+	if index < 0 || index >= len(endpoints) {
+		index = 0
+		endpointIndexes[net] = index
+	}
+
+	return endpoints[index]
 }
 
 func GetTradeAtomKey(t TradeType) (ConfKey, bool) {

--- a/app/router/epusdt.go
+++ b/app/router/epusdt.go
@@ -10,6 +10,7 @@ func epusdtInit(engine *gin.Engine) {
 	epHdr := new(epusdt.Epusdt)
 	{
 		epGrp.GET("/checkout/:trade_id", epHdr.Checkout)
+		epGrp.GET("/cashier/:trade_id", epHdr.Checkout)
 	}
 
 	orderGrp := engine.Group("/api/v1/order")
@@ -26,5 +27,6 @@ func epusdtInit(engine *gin.Engine) {
 		payGrp.POST("/notify", epHdr.Notify)
 		payGrp.POST("/methods", epHdr.GetMethods)
 		payGrp.POST("/update-order", epHdr.UpdateOrder)
+		payGrp.POST("/verify-transaction", epHdr.VerifyTransaction)
 	}
 }

--- a/app/task/aptos.go
+++ b/app/task/aptos.go
@@ -3,7 +3,6 @@ package task
 import (
 	"context"
 	"fmt"
-	"io"
 	"math/big"
 	"net/http"
 	"strings"
@@ -13,7 +12,6 @@ import (
 	"github.com/panjf2000/ants/v2"
 	"github.com/shopspring/decimal"
 	"github.com/smallnest/chanx"
-	"github.com/spf13/cast"
 	"github.com/tidwall/gjson"
 	"github.com/v03413/bepusdt/app/conf"
 	blockapi "github.com/v03413/bepusdt/app/core"
@@ -73,25 +71,17 @@ func (a *aptos) syncVersionForward(ctx context.Context) {
 		return
 	}
 
-	req, _ := http.NewRequestWithContext(ctx, "GET", model.Endpoint(conf.Aptos)+"/v1", nil)
-	resp, err := a.client.Do(req)
+	body, _, err := doRPCRequestWithFailover(ctx, a.client, conf.Aptos, func(endpoint string) (*http.Request, error) {
+		return http.NewRequestWithContext(ctx, "GET", endpoint+"/v1", nil)
+	}, func(body []byte) error {
+		data := gjson.ParseBytes(body)
+		if data.Get("message").String() != "" && data.Get("ledger_version").String() == "" {
+			return fmt.Errorf("%s", data.Get("message").String())
+		}
+		return nil
+	})
 	if err != nil {
-		log.Task.Warn("aptos syncVersionForward Error sending request:", err)
-
-		return
-	}
-
-	defer resp.Body.Close()
-
-	if resp.StatusCode != 200 {
-		log.Task.Warn("aptos syncVersionForward Error response status code:", resp.StatusCode)
-
-		return
-	}
-
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		log.Task.Warn("aptos syncVersionForward Error reading response body:", err)
+		log.Task.Warn("aptos syncVersionForward Error:", err)
 
 		return
 	}
@@ -102,6 +92,7 @@ func (a *aptos) syncVersionForward(ctx context.Context) {
 
 		return
 	}
+	model.SetChainProgress(conf.Aptos, now)
 
 	if now-a.lastVersion > 10000 {
 		a.lastVersion = now - a.versionChunkSize
@@ -191,30 +182,13 @@ func (a *aptos) versionParse(n any) {
 	p := n.(version)
 
 	var net = conf.Aptos
-	var url = fmt.Sprintf("%sv1/transactions?start=%d&limit=%d", model.Endpoint(conf.Aptos), p.Start, p.Limit)
-
-	conf.RecordSuccess(net, cast.ToString(p.Start+p.Limit))
-	resp, err := a.client.Get(url)
+	body, _, err := doRPCRequestWithFailover(context.Background(), a.client, net, func(endpoint string) (*http.Request, error) {
+		url := fmt.Sprintf("%sv1/transactions?start=%d&limit=%d", endpoint, p.Start, p.Limit)
+		return http.NewRequestWithContext(context.Background(), "GET", url, nil)
+	}, nil)
 	if err != nil {
-		conf.RecordFailure(net)
-		log.Task.Warn("versionParse Error sending request:", err)
-
-		return
-	}
-
-	defer resp.Body.Close()
-	if resp.StatusCode != 200 {
-		conf.RecordFailure(net)
-		log.Task.Warn("versionParse Error response status code:", resp.StatusCode)
-
-		return
-	}
-
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		conf.RecordFailure(net)
 		a.versionQueue.In <- p
-		log.Task.Warn("versionParse Error reading response body:", err)
+		log.Task.Warn("versionParse Error:", err)
 
 		return
 	}
@@ -402,36 +376,22 @@ func (a *aptos) tradeConfirmHandle(ctx context.Context) {
 			}
 		}
 
-		req, _ := http.NewRequestWithContext(ctx, "GET", model.Endpoint(conf.Aptos)+"v1/transactions/by_hash/"+o.RefHash, nil)
-		resp, err := a.client.Do(req)
+		body, _, err := doRPCRequestWithFailover(ctx, a.client, conf.Aptos, func(endpoint string) (*http.Request, error) {
+			return http.NewRequestWithContext(ctx, "GET", endpoint+"v1/transactions/by_hash/"+o.RefHash, nil)
+		}, func(body []byte) error {
+			data := gjson.ParseBytes(body)
+			if data.Get("error_code").Exists() {
+				return fmt.Errorf("%s", data.Get("message").String())
+			}
+			return nil
+		})
 		if err != nil {
-			log.Task.Warn("aptos tradeConfirmHandle Error sending request:", err)
-
-			return
-		}
-
-		defer resp.Body.Close()
-
-		if resp.StatusCode != 200 {
-			log.Task.Warn("aptos tradeConfirmHandle Error response status code:", resp.StatusCode)
-
-			return
-		}
-
-		body, err := io.ReadAll(resp.Body)
-		if err != nil {
-			log.Task.Warn("aptos tradeConfirmHandle Error reading response body:", err)
+			log.Task.Warn("aptos tradeConfirmHandle Error:", err)
 
 			return
 		}
 
 		data := gjson.ParseBytes(body)
-		if data.Get("error_code").Exists() {
-			log.Task.Warn("aptos tradeConfirmHandle Error:", data.Get("message").String())
-
-			return
-		}
-
 		if data.Get("version").String() != "" &&
 			data.Get("success").Bool() &&
 			data.Get("vm_status").String() == "Executed successfully" {

--- a/app/task/evm.go
+++ b/app/task/evm.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io"
 	"math/big"
 	"net/http"
 	"strings"
@@ -62,39 +61,12 @@ func (e *evm) syncBlocksForward(ctx context.Context) {
 		return
 	}
 
-	post := []byte(`{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}`)
-	req, err := http.NewRequestWithContext(ctx, "POST", e.rpcEndpoint(), bytes.NewBuffer(post))
-	if err != nil {
-		log.Task.Warn("Error creating request:", err)
-
-		return
-	}
-
-	req.Header.Set("Content-Type", "application/json")
-	resp, err := e.Client.Do(req)
+	now, err := e.latestBlockNumber(ctx)
 	if err != nil {
 		log.Task.Warn("Error sending request:", err)
 
 		return
 	}
-
-	defer resp.Body.Close()
-
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		log.Task.Warn("Error reading response body:", err)
-
-		return
-	}
-
-	var res = gjson.ParseBytes(body)
-	if !res.IsObject() {
-		log.Task.Warn(fmt.Sprintf("EVM 数据解析错误(%s): %s", e.Network, string(body)))
-
-		return
-	}
-
-	var now = utils.HexStr2Int(res.Get("result").String()).Int64() - e.Block.RollDelayOffset
 	if now <= 0 {
 
 		return
@@ -111,6 +83,7 @@ func (e *evm) syncBlocksForward(ctx context.Context) {
 	}
 
 	chainBlockNum.Store(e.Network, now)
+	model.SetChainProgress(model.Network(e.Network), int(now))
 	if now <= lastBlockNumber {
 
 		return
@@ -124,6 +97,33 @@ func (e *evm) syncBlocksForward(ctx context.Context) {
 
 		e.blockScanQueue.In <- evmBlock{From: from, To: to}
 	}
+}
+
+func (e *evm) latestBlockNumber(ctx context.Context) (int64, error) {
+	post := []byte(`{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}`)
+	body, _, err := doRPCRequestWithFailover(ctx, e.Client, e.Network, func(endpoint string) (*http.Request, error) {
+		req, err := http.NewRequestWithContext(ctx, "POST", endpoint, bytes.NewBuffer(post))
+		if err != nil {
+			return nil, err
+		}
+		req.Header.Set("Content-Type", "application/json")
+		return req, nil
+	}, func(body []byte) error {
+		var res = gjson.ParseBytes(body)
+		if !res.IsObject() {
+			return fmt.Errorf("invalid rpc body: %s", string(body))
+		}
+		if data := res.Get("error"); data.Exists() {
+			return errors.New(data.String())
+		}
+		return nil
+	})
+	if err != nil {
+		return 0, err
+	}
+
+	res := gjson.ParseBytes(body)
+	return utils.HexStr2Int(res.Get("result").String()).Int64() - e.Block.RollDelayOffset, nil
 }
 
 func (e *evm) lookbackBlocks(ctx context.Context) {
@@ -200,47 +200,31 @@ func (e *evm) getBlockByNumber(a any) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 	defer cancel()
 
-	req, err := http.NewRequestWithContext(ctx, "POST", e.rpcEndpoint(), bytes.NewBuffer([]byte(fmt.Sprintf(`[%s]`, strings.Join(items, ",")))))
+	body, _, err := doRPCRequestWithFailover(ctx, e.Client, e.Network, func(endpoint string) (*http.Request, error) {
+		req, err := http.NewRequestWithContext(ctx, "POST", endpoint, bytes.NewBuffer([]byte(fmt.Sprintf(`[%s]`, strings.Join(items, ",")))))
+		if err != nil {
+			return nil, err
+		}
+		req.Header.Set("Content-Type", "application/json")
+		return req, nil
+	}, func(body []byte) error {
+		for _, itm := range gjson.ParseBytes(body).Array() {
+			if itm.Get("error").Exists() {
+				return errors.New(itm.Get("error").String())
+			}
+		}
+		return nil
+	})
 	if err != nil {
-		log.Task.Warn("Error creating request:", err)
-
-		return
-	}
-
-	req.Header.Set("Content-Type", "application/json")
-	resp, err := e.Client.Do(req)
-	if err != nil {
-		conf.RecordFailure(e.Network)
 		e.blockScanQueue.In <- b
-		log.Task.Warn("eth_getBlockByNumber Error sending request:", err)
+		log.Task.Warn("eth_getBlockByNumber Error:", err)
 
 		return
 	}
-
-	defer resp.Body.Close()
-
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		conf.RecordFailure(e.Network)
-		e.blockScanQueue.In <- b
-		log.Task.Warn("eth_getBlockByNumber Error reading response body:", err)
-
-		return
-	}
-
-	conf.RecordSuccess(e.Network, cast.ToString(b.To))
 
 	nativeTransfers := make([]transfer, 0)
 	blockTimestamp := make(map[string]time.Time)
 	for _, itm := range gjson.ParseBytes(body).Array() {
-		if itm.Get("error").Exists() {
-			conf.RecordFailure(e.Network)
-			e.blockScanQueue.In <- b
-			log.Task.Warn(fmt.Sprintf("%s eth_getBlockByNumber response error %s", e.Network, itm.Get("error").String()))
-
-			return
-		}
-
 		timestamp := utils.HexStr2Int(itm.Get("result.timestamp").String()).Int64()
 		blockTime := time.Unix(timestamp, 0)
 		blockNumHex := itm.Get("result.number").String()
@@ -318,25 +302,26 @@ func (e *evm) parseNativeTransfer(array []gjson.Result, num int, timestamp time.
 func (e *evm) parseEventTransfer(b evmBlock, timestamp map[string]time.Time) ([]transfer, error) {
 	transfers := make([]transfer, 0)
 	post := []byte(fmt.Sprintf(`{"jsonrpc":"2.0","method":"eth_getLogs","params":[{"fromBlock":"0x%x","toBlock":"0x%x","topics":["%s"]}],"id":1}`, b.From, b.To, evmTransferEvent))
-	resp, err := e.Client.Post(e.rpcEndpoint(), "application/json", bytes.NewBuffer(post))
+	body, _, err := doRPCRequestWithFailover(context.Background(), e.Client, e.Network, func(endpoint string) (*http.Request, error) {
+		req, err := http.NewRequestWithContext(context.Background(), "POST", endpoint, bytes.NewBuffer(post))
+		if err != nil {
+			return nil, err
+		}
+		req.Header.Set("Content-Type", "application/json")
+		return req, nil
+	}, func(body []byte) error {
+		data := gjson.ParseBytes(body)
+		if data.Get("error").Exists() {
+			return errors.New(data.Get("error").String())
+		}
+		return nil
+	})
 	if err != nil {
 
-		return transfers, errors.Join(errors.New("eth_getLogs Post Error"), err)
-	}
-
-	defer resp.Body.Close()
-
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-
-		return transfers, errors.Join(errors.New("eth_getLogs ReadAll Error"), err)
+		return transfers, errors.Join(errors.New("eth_getLogs request error"), err)
 	}
 
 	data := gjson.ParseBytes(body)
-	if data.Get("error").Exists() {
-
-		return transfers, errors.New(fmt.Sprintf("%s eth_getLogs response error %s", e.Network, data.Get("error").String()))
-	}
 
 	for _, itm := range data.Get("result").Array() {
 		to := itm.Get("address").String()
@@ -396,36 +381,27 @@ func (e *evm) tradeConfirmHandle(ctx context.Context) {
 		}
 
 		post := []byte(fmt.Sprintf(`{"jsonrpc":"2.0","method":"eth_getTransactionReceipt","params":["%s"],"id":1}`, o.RefHash))
-		req, err := http.NewRequestWithContext(ctx, "POST", e.rpcEndpoint(), bytes.NewBuffer(post))
+		body, _, err := doRPCRequestWithFailover(ctx, e.Client, e.Network, func(endpoint string) (*http.Request, error) {
+			req, err := http.NewRequestWithContext(ctx, "POST", endpoint, bytes.NewBuffer(post))
+			if err != nil {
+				return nil, err
+			}
+			req.Header.Set("Content-Type", "application/json")
+			return req, nil
+		}, func(body []byte) error {
+			data := gjson.ParseBytes(body)
+			if data.Get("error").Exists() {
+				return errors.New(data.Get("error").String())
+			}
+			return nil
+		})
 		if err != nil {
-			log.Task.Warn("evm tradeConfirmHandle Error creating request:", err)
-
-			return
-		}
-
-		req.Header.Set("Content-Type", "application/json")
-		resp, err := e.Client.Do(req)
-		if err != nil {
-			log.Task.Warn("evm tradeConfirmHandle Error sending request:", err)
-
-			return
-		}
-
-		defer resp.Body.Close()
-
-		body, err := io.ReadAll(resp.Body)
-		if err != nil {
-			log.Task.Warn("evm tradeConfirmHandle Error reading response body:", err)
+			log.Task.Warn("evm tradeConfirmHandle Error:", err)
 
 			return
 		}
 
 		data := gjson.ParseBytes(body)
-		if data.Get("error").Exists() {
-			log.Task.Warn(fmt.Sprintf("%s eth_getTransactionReceipt response error %s", e.Network, data.Get("error").String()))
-
-			return
-		}
 
 		if data.Get("result.status").String() == "0x1" {
 			markFinalConfirmed(o)

--- a/app/task/evm.go
+++ b/app/task/evm.go
@@ -208,9 +208,18 @@ func (e *evm) getBlockByNumber(a any) {
 		req.Header.Set("Content-Type", "application/json")
 		return req, nil
 	}, func(body []byte) error {
-		for _, itm := range gjson.ParseBytes(body).Array() {
+		items := gjson.ParseBytes(body).Array()
+		expected := int(b.To - b.From + 1)
+		if len(items) != expected {
+			return fmt.Errorf("incomplete block batch response: expected %d blocks, got %d", expected, len(items))
+		}
+		for _, itm := range items {
 			if itm.Get("error").Exists() {
 				return errors.New(itm.Get("error").String())
+			}
+			result := itm.Get("result")
+			if !result.Exists() || result.Raw == "null" || result.Get("number").String() == "" || result.Get("timestamp").String() == "" {
+				return fmt.Errorf("block %s is temporarily unavailable", result.Get("number").String())
 			}
 		}
 		return nil

--- a/app/task/evm_block_retry_test.go
+++ b/app/task/evm_block_retry_test.go
@@ -1,0 +1,48 @@
+package task
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/smallnest/chanx"
+	"github.com/v03413/bepusdt/app/conf"
+	"github.com/v03413/bepusdt/app/model"
+)
+
+func TestEvmBlockParseRequeuesWhenRPCBlockIsTemporarilyUnavailable(t *testing.T) {
+	initSolanaReconcileTestLog(t)
+
+	if err := model.Init(filepath.Join(t.TempDir(), "evm-null-block.db"), "", ""); err != nil {
+		t.Fatalf("init test db: %v", err)
+	}
+	t.Cleanup(model.Close)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`[{"jsonrpc":"2.0","id":113093582,"result":null}]`))
+	}))
+	defer server.Close()
+
+	model.SetK(model.RpcEndpointBsc, server.URL)
+	model.RefreshC()
+
+	block := evmBlock{From: 113093582, To: 113093582}
+	scanner := evm{
+		Network:        conf.Bsc,
+		Client:         server.Client(),
+		blockScanQueue: chanx.NewUnboundedChan[evmBlock](context.Background(), 30),
+	}
+	scanner.getBlockByNumber(block)
+
+	select {
+	case got := <-scanner.blockScanQueue.Out:
+		if got != block {
+			t.Fatalf("expected block %+v to be requeued, got %+v", block, got)
+		}
+	case <-time.After(time.Second):
+		t.Fatalf("expected temporarily unavailable block %+v to be requeued", block)
+	}
+}

--- a/app/task/payment_verification.go
+++ b/app/task/payment_verification.go
@@ -1,0 +1,341 @@
+package task
+
+import (
+	"bytes"
+	"context"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"math/big"
+	"net/http"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/shopspring/decimal"
+	"github.com/spf13/cast"
+	"github.com/tidwall/gjson"
+	"github.com/v03413/bepusdt/app/conf"
+	"github.com/v03413/bepusdt/app/model"
+	"github.com/v03413/bepusdt/app/utils"
+	"github.com/v03413/tronprotocol/api"
+	"github.com/v03413/tronprotocol/core"
+)
+
+var (
+	ErrInvalidSubmittedPaymentHash  = errors.New("invalid submitted payment hash")
+	ErrUnsupportedSubmittedPayment  = errors.New("submitted payment verification is unsupported for this network")
+	ErrSubmittedPaymentNotFound     = errors.New("submitted payment transaction was not found or is not finalized")
+	ErrSubmittedPaymentDoesNotMatch = errors.New("submitted payment does not match this order")
+)
+
+type submittedPaymentLookup func(context.Context, model.Order, string) (transfer, error)
+
+var tronPaymentHashPattern = regexp.MustCompile(`^[0-9a-fA-F]{64}$`)
+var evmPaymentHashPattern = regexp.MustCompile(`^(0x)?[0-9a-fA-F]{64}$`)
+
+// VerifySubmittedPayment fetches a transaction from the order's chain and
+// verifies it using the exact same matching rules as the scanner. The caller
+// is responsible for atomically claiming the verified transaction hash.
+func VerifySubmittedPayment(ctx context.Context, order model.Order, hash string) (transfer, error) {
+	return verifySubmittedPayment(ctx, order, hash, lookupSubmittedPayment)
+}
+
+// VerifyAndClaimSubmittedPayment verifies a payer-supplied transaction hash and
+// atomically reserves it for this order before moving it to confirming.
+func VerifyAndClaimSubmittedPayment(ctx context.Context, order *model.Order, hash string) (bool, error) {
+	if order == nil {
+		return false, fmt.Errorf("verify submitted payment: order is required")
+	}
+	payment, err := VerifySubmittedPayment(ctx, *order, hash)
+	if err != nil {
+		return false, err
+	}
+	return model.ClaimPaymentConfirmation(order, model.PaymentConfirmation{
+		BlockNum: payment.BlockNum,
+		From:     payment.FromAddress,
+		Hash:     payment.TxHash,
+		At:       payment.Timestamp,
+		Amount:   payment.Amount,
+	})
+}
+
+func verifySubmittedPayment(ctx context.Context, order model.Order, hash string, lookup submittedPaymentLookup) (transfer, error) {
+	normalizedHash, err := normalizeSubmittedPaymentHash(order.TradeType, hash)
+	if err != nil {
+		return transfer{}, err
+	}
+
+	payment, err := lookup(ctx, order, normalizedHash)
+	if err != nil {
+		return transfer{}, err
+	}
+	if !sameSubmittedPaymentHash(order.TradeType, payment.TxHash, normalizedHash) {
+		return transfer{}, fmt.Errorf("%w: lookup returned a different transaction", ErrSubmittedPaymentDoesNotMatch)
+	}
+	if reason := orderTransferMatchReason(order, payment); reason != orderMatchOK {
+		return transfer{}, fmt.Errorf("%w: %s", ErrSubmittedPaymentDoesNotMatch, reason)
+	}
+
+	payment.TxHash = normalizedHash
+	return payment, nil
+}
+
+func normalizeSubmittedPaymentHash(tradeType model.TradeType, hash string) (string, error) {
+	hash = strings.TrimSpace(hash)
+	switch {
+	case isTronTrade(tradeType):
+		hash = strings.TrimPrefix(strings.ToLower(hash), "0x")
+		if !tronPaymentHashPattern.MatchString(hash) {
+			return "", ErrInvalidSubmittedPaymentHash
+		}
+		return hash, nil
+	case isBscTrade(tradeType):
+		if !evmPaymentHashPattern.MatchString(hash) {
+			return "", ErrInvalidSubmittedPaymentHash
+		}
+		return "0x" + strings.TrimPrefix(strings.ToLower(hash), "0x"), nil
+	default:
+		return "", ErrUnsupportedSubmittedPayment
+	}
+}
+
+func sameSubmittedPaymentHash(tradeType model.TradeType, left, right string) bool {
+	normalizedLeft, leftErr := normalizeSubmittedPaymentHash(tradeType, left)
+	normalizedRight, rightErr := normalizeSubmittedPaymentHash(tradeType, right)
+	return leftErr == nil && rightErr == nil && normalizedLeft == normalizedRight
+}
+
+func isTronTrade(tradeType model.TradeType) bool {
+	return tradeType == model.TronTrx || tradeType == model.UsdtTrc20 || tradeType == model.UsdcTrc20
+}
+
+func isBscTrade(tradeType model.TradeType) bool {
+	return tradeType == model.BscBnb || tradeType == model.UsdtBep20 || tradeType == model.UsdcBep20
+}
+
+func lookupSubmittedPayment(ctx context.Context, order model.Order, hash string) (transfer, error) {
+	switch {
+	case isTronTrade(order.TradeType):
+		return lookupTronSubmittedPayment(ctx, order, hash)
+	case isBscTrade(order.TradeType):
+		return lookupBscSubmittedPayment(ctx, order, hash)
+	default:
+		return transfer{}, ErrUnsupportedSubmittedPayment
+	}
+}
+
+func lookupTronSubmittedPayment(ctx context.Context, order model.Order, hash string) (transfer, error) {
+	id, err := hex.DecodeString(hash)
+	if err != nil {
+		return transfer{}, ErrInvalidSubmittedPaymentHash
+	}
+	conn, err := tr.client()
+	if err != nil {
+		return transfer{}, fmt.Errorf("query TRON transaction: %w", err)
+	}
+	client := api.NewWalletClient(conn)
+	queryCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
+	defer cancel()
+
+	transaction, err := client.GetTransactionById(queryCtx, &api.BytesMessage{Value: id})
+	if err != nil {
+		reportRPCFailure(conf.Tron, model.Endpoint(conf.Tron), err)
+		return transfer{}, fmt.Errorf("query TRON transaction: %w", err)
+	}
+	info, err := client.GetTransactionInfoById(queryCtx, &api.BytesMessage{Value: id})
+	if err != nil {
+		reportRPCFailure(conf.Tron, model.Endpoint(conf.Tron), err)
+		return transfer{}, fmt.Errorf("query TRON transaction receipt: %w", err)
+	}
+	if info.GetBlockNumber() <= 0 || info.GetBlockTimeStamp() <= 0 || info.GetReceipt() == nil ||
+		info.GetReceipt().GetResult() != core.Transaction_Result_SUCCESS {
+		return transfer{}, ErrSubmittedPaymentNotFound
+	}
+
+	candidates := tr.parseSubmittedTransaction(hash, transaction, time.UnixMilli(info.GetBlockTimeStamp()), int(info.GetBlockNumber()))
+	for _, payment := range candidates {
+		if payment.TradeType == order.TradeType {
+			return payment, nil
+		}
+	}
+
+	return transfer{}, ErrSubmittedPaymentDoesNotMatch
+}
+
+func (t *tron) parseSubmittedTransaction(hash string, transaction *core.Transaction, timestamp time.Time, blockNum int) []transfer {
+	transfers := make([]transfer, 0, 1)
+	for _, contract := range transaction.GetRawData().GetContract() {
+		switch contract.GetType() {
+		case core.Transaction_Contract_TransferContract:
+			item := &core.TransferContract{}
+			if err := contract.GetParameter().UnmarshalTo(item); err != nil {
+				continue
+			}
+			transfers = append(transfers, transfer{
+				Network:     conf.Tron,
+				TxHash:      hash,
+				Amount:      decimal.NewFromBigInt(big.NewInt(item.Amount), -6),
+				FromAddress: t.base58CheckEncode(item.OwnerAddress),
+				RecvAddress: t.base58CheckEncode(item.ToAddress),
+				Timestamp:   timestamp,
+				TradeType:   model.TronTrx,
+				BlockNum:    blockNum,
+			})
+		case core.Transaction_Contract_TriggerSmartContract:
+			item := &core.TriggerSmartContract{}
+			if err := contract.GetParameter().UnmarshalTo(item); err != nil {
+				continue
+			}
+			data := item.GetData()
+			if len(data) < 4 {
+				continue
+			}
+
+			if bytes.Equal(item.OwnerAddress, gasFreeOwnerAddress) && bytes.Equal(item.ContractAddress, gasFreeContractAddress) {
+				from, receiver, amount := t.gasFreePermitTransfer(data)
+				if amount != nil {
+					transfers = append(transfers, transfer{
+						Network: conf.Tron, TxHash: hash, Amount: decimal.NewFromBigInt(amount, conf.UsdtTronDecimals),
+						FromAddress: from, RecvAddress: receiver, Timestamp: timestamp, TradeType: model.UsdtTrc20, BlockNum: blockNum,
+					})
+				}
+			}
+
+			tradeType, ok := tronContractTradeType(item.GetContractAddress())
+			if !ok {
+				continue
+			}
+			if bytes.Equal(data[:4], []byte{0xa9, 0x05, 0x9c, 0xbb}) {
+				receiver, amount := t.parseTrc20ContractTransfer(data)
+				if amount != nil {
+					transfers = append(transfers, transfer{
+						Network: conf.Tron, TxHash: hash, Amount: decimal.NewFromBigInt(amount, model.GetTradeDecimal(tradeType)),
+						FromAddress: t.base58CheckEncode(item.OwnerAddress), RecvAddress: receiver, Timestamp: timestamp, TradeType: tradeType, BlockNum: blockNum,
+					})
+				}
+			}
+			if bytes.Equal(data[:4], []byte{0x23, 0xb8, 0x72, 0xdd}) {
+				from, receiver, amount := t.parseTrc20ContractTransferFrom(data)
+				if amount != nil {
+					transfers = append(transfers, transfer{
+						Network: conf.Tron, TxHash: hash, Amount: decimal.NewFromBigInt(amount, model.GetTradeDecimal(tradeType)),
+						FromAddress: from, RecvAddress: receiver, Timestamp: timestamp, TradeType: tradeType, BlockNum: blockNum,
+					})
+				}
+			}
+		}
+	}
+	return transfers
+}
+
+func tronContractTradeType(address []byte) (model.TradeType, bool) {
+	switch {
+	case bytes.Equal(address, usdtTrc20ContractAddress):
+		return model.UsdtTrc20, true
+	case bytes.Equal(address, usdcTrc20ContractAddress):
+		return model.UsdcTrc20, true
+	default:
+		return "", false
+	}
+}
+
+func lookupBscSubmittedPayment(ctx context.Context, order model.Order, hash string) (transfer, error) {
+	e := evm{Network: conf.Bsc, Client: utils.NewHttpClient()}
+	receipt, err := e.submittedRPC(ctx, "eth_getTransactionReceipt", fmt.Sprintf(`[%q]`, hash))
+	if err != nil {
+		return transfer{}, err
+	}
+	if !strings.EqualFold(receipt.Get("status").String(), "0x1") {
+		return transfer{}, ErrSubmittedPaymentNotFound
+	}
+	blockNumber := receipt.Get("blockNumber").String()
+	if blockNumber == "" {
+		return transfer{}, ErrSubmittedPaymentNotFound
+	}
+	block, err := e.submittedRPC(ctx, "eth_getBlockByNumber", fmt.Sprintf(`[%q,false]`, blockNumber))
+	if err != nil {
+		return transfer{}, err
+	}
+	timestamp := time.Unix(utils.HexStr2Int(block.Get("timestamp").String()).Int64(), 0)
+	blockNum := cast.ToInt(utils.HexStr2Int(blockNumber).Int64())
+	if timestamp.IsZero() || blockNum <= 0 {
+		return transfer{}, ErrSubmittedPaymentNotFound
+	}
+
+	if order.TradeType == model.BscBnb {
+		transaction, err := e.submittedRPC(ctx, "eth_getTransactionByHash", fmt.Sprintf(`[%q]`, hash))
+		if err != nil {
+			return transfer{}, err
+		}
+		if transaction.Get("input").String() != "0x" || transaction.Get("to").String() == "" {
+			return transfer{}, ErrSubmittedPaymentDoesNotMatch
+		}
+		amount, ok := new(big.Int).SetString(strings.TrimPrefix(transaction.Get("value").String(), "0x"), 16)
+		if !ok || amount.Sign() <= 0 {
+			return transfer{}, ErrSubmittedPaymentDoesNotMatch
+		}
+		return transfer{
+			Network: conf.Bsc, TxHash: hash, Amount: decimal.NewFromBigInt(amount, conf.BscBnbDecimals),
+			FromAddress: transaction.Get("from").String(), RecvAddress: transaction.Get("to").String(), Timestamp: timestamp,
+			TradeType: model.BscBnb, BlockNum: blockNum,
+		}, nil
+	}
+
+	for _, item := range receipt.Get("logs").Array() {
+		tradeType, ok := model.GetContractTrade(strings.ToLower(item.Get("address").String()))
+		if !ok || tradeType != order.TradeType {
+			continue
+		}
+		topics := item.Get("topics").Array()
+		if len(topics) < 3 || !strings.EqualFold(topics[0].String(), evmTransferEvent) {
+			continue
+		}
+		from, fromOK := evmTopicAddress(topics[1].String())
+		recipient, recipientOK := evmTopicAddress(topics[2].String())
+		amount, amountOK := new(big.Int).SetString(strings.TrimPrefix(item.Get("data").String(), "0x"), 16)
+		if !fromOK || !recipientOK || !amountOK || amount.Sign() <= 0 {
+			continue
+		}
+		return transfer{
+			Network: conf.Bsc, TxHash: hash, Amount: decimal.NewFromBigInt(amount, model.GetTradeDecimal(tradeType)),
+			FromAddress: from, RecvAddress: recipient, Timestamp: timestamp, TradeType: tradeType, BlockNum: blockNum,
+		}, nil
+	}
+
+	return transfer{}, ErrSubmittedPaymentDoesNotMatch
+}
+
+func (e evm) submittedRPC(ctx context.Context, method, params string) (gjson.Result, error) {
+	body, _, err := doRPCRequestWithFailover(ctx, e.Client, e.Network, func(endpoint string) (*http.Request, error) {
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, strings.NewReader(
+			fmt.Sprintf(`{"jsonrpc":"2.0","method":%q,"params":%s,"id":1}`, method, params),
+		))
+		if err != nil {
+			return nil, err
+		}
+		req.Header.Set("Content-Type", "application/json")
+		return req, nil
+	}, func(body []byte) error {
+		data := gjson.ParseBytes(body)
+		if data.Get("error").Exists() {
+			return errors.New(data.Get("error").String())
+		}
+		if !data.Get("result").Exists() {
+			return ErrSubmittedPaymentNotFound
+		}
+		return nil
+	})
+	if err != nil {
+		return gjson.Result{}, fmt.Errorf("query BSC transaction: %w", err)
+	}
+	return gjson.ParseBytes(body).Get("result"), nil
+}
+
+func evmTopicAddress(topic string) (string, bool) {
+	topic = strings.TrimPrefix(strings.ToLower(topic), "0x")
+	if len(topic) != 64 || !tronPaymentHashPattern.MatchString(topic) {
+		return "", false
+	}
+	return "0x" + topic[24:], true
+}

--- a/app/task/payment_verification_test.go
+++ b/app/task/payment_verification_test.go
@@ -1,0 +1,233 @@
+package task
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/shopspring/decimal"
+	"github.com/v03413/bepusdt/app/conf"
+	"github.com/v03413/bepusdt/app/model"
+)
+
+func TestOrderTransferMatchReproducesAffectedTRC20Payment(t *testing.T) {
+	if err := model.Init(filepath.Join(t.TempDir(), "bepusdt.db"), "", ""); err != nil {
+		t.Fatalf("initialize test database: %v", err)
+	}
+
+	createdAt := time.Date(2026, 7, 19, 14, 2, 20, 0, time.UTC)
+	order := model.Order{
+		TradeType:    model.UsdtTrc20,
+		Amount:       "65.94",
+		Address:      "TKNUJShSXfCDii9bxdguPwgZsKXG6rBLC6",
+		MatchAddress: "TKNUJShSXfCDii9bxdguPwgZsKXG6rBLC6",
+		ExpiredAt:    createdAt.Add(30 * time.Minute),
+		AutoTimeAt:   model.AutoTimeAt{CreatedAt: (*model.Datetime)(&createdAt)},
+	}
+	transfer := transfer{
+		Network:     conf.Tron,
+		TxHash:      "303245e65da6dca3e7aed8dc5386cd0cbbc7f67e4c21ff4ee0d9330055a41983",
+		TradeType:   model.UsdtTrc20,
+		Amount:      decimal.RequireFromString("65.94"),
+		RecvAddress: "TKNUJShSXfCDii9bxdguPwgZsKXG6rBLC6",
+		Timestamp:   time.Date(2026, 7, 19, 14, 7, 6, 0, time.UTC),
+		BlockNum:    84599893,
+	}
+
+	if reason := orderTransferMatchReason(order, transfer); reason != orderMatchOK {
+		t.Fatalf("affected payment should match, got reason %q", reason)
+	}
+}
+
+func TestGetReceivableOrdersReturnsDatabaseReadFailure(t *testing.T) {
+	if err := model.Init(filepath.Join(t.TempDir(), "bepusdt.db"), "", ""); err != nil {
+		t.Fatalf("initialize test database: %v", err)
+	}
+	sqlDB, err := model.Db.DB()
+	if err != nil {
+		t.Fatalf("get sql database: %v", err)
+	}
+	if err := sqlDB.Close(); err != nil {
+		t.Fatalf("close test database: %v", err)
+	}
+
+	if _, err := getReceivableOrders(); err == nil {
+		t.Fatal("receivable-order query failure must be returned so transfers can be retried")
+	}
+}
+
+func TestNormalizeSubmittedPaymentHash(t *testing.T) {
+	if _, err := normalizeSubmittedPaymentHash(model.UsdtTrc20, "not-a-hash"); !errors.Is(err, ErrInvalidSubmittedPaymentHash) {
+		t.Fatalf("invalid TRON hash error = %v, want ErrInvalidSubmittedPaymentHash", err)
+	}
+	if _, err := normalizeSubmittedPaymentHash(model.UsdtErc20, strings.Repeat("a", 64)); !errors.Is(err, ErrUnsupportedSubmittedPayment) {
+		t.Fatalf("unsupported network error = %v, want ErrUnsupportedSubmittedPayment", err)
+	}
+
+	normalized, err := normalizeSubmittedPaymentHash(model.UsdtBep20, strings.Repeat("A", 64))
+	if err != nil {
+		t.Fatalf("normalize BSC hash: %v", err)
+	}
+	if normalized != "0x"+strings.Repeat("a", 64) {
+		t.Fatalf("normalized BSC hash = %q", normalized)
+	}
+}
+
+func TestOrderTransferMatchReasonIdentifiesMismatch(t *testing.T) {
+	if err := model.Init(filepath.Join(t.TempDir(), "bepusdt.db"), "", ""); err != nil {
+		t.Fatalf("initialize test database: %v", err)
+	}
+
+	now := time.Now().UTC()
+	order := model.Order{
+		TradeType:    model.UsdtBep20,
+		Amount:       "17.54",
+		Address:      "0x00000000000000000000000000000000000000aa",
+		MatchAddress: "0x00000000000000000000000000000000000000aa",
+		ExpiredAt:    now.Add(time.Minute),
+		AutoTimeAt:   model.AutoTimeAt{CreatedAt: (*model.Datetime)(&now)},
+	}
+	matchedTransfer := transfer{
+		Network:     conf.Bsc,
+		TradeType:   model.UsdtBep20,
+		Amount:      decimal.RequireFromString("17.54"),
+		RecvAddress: "0x00000000000000000000000000000000000000AA",
+		Timestamp:   now.Add(time.Second),
+	}
+	if reason := orderTransferMatchReason(order, matchedTransfer); reason != orderMatchOK {
+		t.Fatalf("EVM addresses must match case-insensitively, got reason %q", reason)
+	}
+
+	matchedTransfer.TradeType = model.UsdcBep20
+	if reason := orderTransferMatchReason(order, matchedTransfer); reason != orderMatchTradeType {
+		t.Fatalf("expected trade type mismatch, got reason %q", reason)
+	}
+	matchedTransfer.TradeType = model.UsdtBep20
+
+	matchedTransfer.RecvAddress = "0x00000000000000000000000000000000000000bb"
+	if reason := orderTransferMatchReason(order, matchedTransfer); reason != orderMatchReceivingAddress {
+		t.Fatalf("expected recipient mismatch, got reason %q", reason)
+	}
+	matchedTransfer.RecvAddress = "0x00000000000000000000000000000000000000AA"
+
+	matchedTransfer.Amount = decimal.RequireFromString("17.55")
+	if reason := orderTransferMatchReason(order, matchedTransfer); reason != orderMatchAmount {
+		t.Fatalf("expected amount mismatch, got reason %q", reason)
+	}
+	matchedTransfer.Amount = decimal.RequireFromString("17.54")
+	matchedTransfer.Timestamp = now
+	if reason := orderTransferMatchReason(order, matchedTransfer); reason != orderMatchPaymentTimeWindow {
+		t.Fatalf("expected payment time mismatch, got reason %q", reason)
+	}
+}
+
+func TestVerifySubmittedPaymentUsesCanonicalOrderMatch(t *testing.T) {
+	if err := model.Init(filepath.Join(t.TempDir(), "bepusdt.db"), "", ""); err != nil {
+		t.Fatalf("initialize test database: %v", err)
+	}
+
+	now := time.Now().UTC()
+	order := model.Order{
+		TradeType:    model.UsdtTrc20,
+		Amount:       "65.94",
+		Address:      "TKNUJShSXfCDii9bxdguPwgZsKXG6rBLC6",
+		MatchAddress: "TKNUJShSXfCDii9bxdguPwgZsKXG6rBLC6",
+		ExpiredAt:    now.Add(time.Minute),
+		AutoTimeAt:   model.AutoTimeAt{CreatedAt: (*model.Datetime)(&now)},
+	}
+	valid := transfer{
+		Network:     conf.Tron,
+		TxHash:      "303245e65da6dca3e7aed8dc5386cd0cbbc7f67e4c21ff4ee0d9330055a41983",
+		TradeType:   model.UsdtTrc20,
+		Amount:      decimal.RequireFromString("65.94"),
+		RecvAddress: order.MatchAddress,
+		Timestamp:   now.Add(time.Second),
+		BlockNum:    1,
+	}
+	lookup := func(context.Context, model.Order, string) (transfer, error) {
+		return valid, nil
+	}
+
+	got, err := verifySubmittedPayment(context.Background(), order, valid.TxHash, lookup)
+	if err != nil {
+		t.Fatalf("verify valid submitted payment: %v", err)
+	}
+	if got.TxHash != valid.TxHash {
+		t.Fatalf("verified hash = %s, want %s", got.TxHash, valid.TxHash)
+	}
+
+	wrongAddress := func(context.Context, model.Order, string) (transfer, error) {
+		t := valid
+		t.RecvAddress = "TWrongAddress"
+		return t, nil
+	}
+	if _, err := verifySubmittedPayment(context.Background(), order, valid.TxHash, wrongAddress); !errors.Is(err, ErrSubmittedPaymentDoesNotMatch) {
+		t.Fatalf("wrong recipient error = %v, want ErrSubmittedPaymentDoesNotMatch", err)
+	}
+}
+
+func TestVerifySubmittedPaymentFetchesAndValidatesBscTransfer(t *testing.T) {
+	if err := model.Init(filepath.Join(t.TempDir(), "bepusdt.db"), "", ""); err != nil {
+		t.Fatalf("initialize test database: %v", err)
+	}
+
+	const transactionHash = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	const sender = "0x0000000000000000000000000000000000000001"
+	const receiver = "0x00000000000000000000000000000000000000aa"
+	const blockNumber = "0x64"
+	const timestamp = "0x6694b540"
+	amount := big.NewInt(0)
+	amount.SetString("17540000000000000000", 10)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var request struct {
+			Method string `json:"method"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+			t.Fatalf("decode RPC request: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		switch request.Method {
+		case "eth_getTransactionReceipt":
+			_, _ = fmt.Fprintf(w, `{"jsonrpc":"2.0","id":1,"result":{"status":"0x1","blockNumber":%q,"logs":[{"address":%q,"topics":[%q,%q,%q],"data":%q}]}}`,
+				blockNumber, conf.UsdtBep20, evmTransferEvent, paddedEvmTopic(sender), paddedEvmTopic(receiver), "0x"+amount.Text(16))
+		case "eth_getBlockByNumber":
+			_, _ = fmt.Fprintf(w, `{"jsonrpc":"2.0","id":1,"result":{"number":%q,"timestamp":%q}}`, blockNumber, timestamp)
+		default:
+			t.Fatalf("unexpected BSC RPC method: %s", request.Method)
+		}
+	}))
+	defer server.Close()
+	model.SetK(model.RpcEndpointBsc, server.URL)
+
+	blockTime := time.Unix(0x6694b540, 0)
+	createdAt := blockTime.Add(-time.Minute)
+	order := model.Order{
+		TradeType:    model.UsdtBep20,
+		Amount:       "17.54",
+		Address:      receiver,
+		MatchAddress: receiver,
+		ExpiredAt:    blockTime.Add(time.Minute),
+		AutoTimeAt:   model.AutoTimeAt{CreatedAt: (*model.Datetime)(&createdAt)},
+	}
+
+	payment, err := verifySubmittedPayment(context.Background(), order, transactionHash, lookupSubmittedPayment)
+	if err != nil {
+		t.Fatalf("verify BSC transaction: %v", err)
+	}
+	if payment.TradeType != model.UsdtBep20 || payment.RecvAddress != receiver || !payment.Amount.Equal(decimal.RequireFromString("17.54")) {
+		t.Fatalf("unexpected verified BSC payment: %+v", payment)
+	}
+}
+
+func paddedEvmTopic(address string) string {
+	return "0x" + strings.Repeat("0", 24) + strings.TrimPrefix(strings.ToLower(address), "0x")
+}

--- a/app/task/rpc.go
+++ b/app/task/rpc.go
@@ -1,0 +1,108 @@
+package task
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+
+	"github.com/v03413/bepusdt/app/conf"
+	"github.com/v03413/bepusdt/app/log"
+	"github.com/v03413/bepusdt/app/model"
+)
+
+func reportRPCFailure(network, endpoint string, reason any) {
+	conf.RecordFailure(network)
+
+	next := model.ReportEndpointFailure(model.Network(network), endpoint)
+	if log.Task == nil {
+		return
+	}
+
+	if next == "" || next == endpoint {
+		log.Task.Warn(fmt.Sprintf("%s RPC endpoint failed: %v", network, reason))
+		return
+	}
+
+	log.Task.Warn(fmt.Sprintf(
+		"%s RPC endpoint failed: %v; switching %s -> %s",
+		network,
+		reason,
+		maskEndpoint(endpoint),
+		maskEndpoint(next),
+	))
+}
+
+func maskEndpoint(endpoint string) string {
+	u, err := url.Parse(endpoint)
+	if err != nil || u.Scheme == "" || u.Host == "" {
+		return endpoint
+	}
+
+	u.User = nil
+	u.RawQuery = ""
+	u.Fragment = ""
+
+	return u.String()
+}
+
+func doRPCRequestWithFailover(
+	ctx context.Context,
+	client *http.Client,
+	network string,
+	build func(endpoint string) (*http.Request, error),
+	validate func(body []byte) error,
+) ([]byte, string, error) {
+	candidates := model.EndpointCandidates(model.Network(network))
+	if len(candidates) == 0 {
+		return nil, "", fmt.Errorf("%s rpc endpoint is empty", network)
+	}
+
+	var lastErr error
+	for range candidates {
+		endpoint := model.Endpoint(model.Network(network))
+		req, err := build(endpoint)
+		if err != nil {
+			lastErr = err
+			reportRPCFailure(network, endpoint, err)
+			continue
+		}
+
+		resp, err := client.Do(req.WithContext(ctx))
+		if err != nil {
+			lastErr = err
+			reportRPCFailure(network, endpoint, err)
+			continue
+		}
+
+		body, readErr := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		if readErr != nil {
+			lastErr = readErr
+			reportRPCFailure(network, endpoint, readErr)
+			continue
+		}
+		if resp.StatusCode != http.StatusOK {
+			lastErr = fmt.Errorf("status code %d", resp.StatusCode)
+			reportRPCFailure(network, endpoint, lastErr)
+			continue
+		}
+		if validate != nil {
+			if err := validate(body); err != nil {
+				lastErr = err
+				reportRPCFailure(network, endpoint, err)
+				continue
+			}
+		}
+
+		conf.RecordSuccess(network, endpoint)
+		return body, endpoint, nil
+	}
+
+	if lastErr == nil {
+		lastErr = fmt.Errorf("%s rpc request failed without details", network)
+	}
+
+	return nil, "", lastErr
+}

--- a/app/task/rpc.go
+++ b/app/task/rpc.go
@@ -2,6 +2,7 @@ package task
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -11,6 +12,17 @@ import (
 	"github.com/v03413/bepusdt/app/log"
 	"github.com/v03413/bepusdt/app/model"
 )
+
+type rpcTerminalError struct {
+	err error
+}
+
+func (e rpcTerminalError) Error() string { return e.err.Error() }
+func (e rpcTerminalError) Unwrap() error { return e.err }
+
+func terminalRPCError(err error) error {
+	return rpcTerminalError{err: err}
+}
 
 func reportRPCFailure(network, endpoint string, reason any) {
 	conf.RecordFailure(network)
@@ -91,6 +103,10 @@ func doRPCRequestWithFailover(
 		if validate != nil {
 			if err := validate(body); err != nil {
 				lastErr = err
+				var terminal rpcTerminalError
+				if errors.As(err, &terminal) {
+					return nil, endpoint, err
+				}
 				reportRPCFailure(network, endpoint, err)
 				continue
 			}

--- a/app/task/rpc_failover_test.go
+++ b/app/task/rpc_failover_test.go
@@ -1,0 +1,95 @@
+package task
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+
+	"github.com/smallnest/chanx"
+	"github.com/v03413/bepusdt/app/conf"
+	"github.com/v03413/bepusdt/app/model"
+)
+
+func TestEvmSyncBlocksForwardRotatesEndpointOnInvalidRPCResponse(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "evm-rpc-failover.db")
+	if err := model.Init(dbPath, "", ""); err != nil {
+		t.Fatalf("init test db: %v", err)
+	}
+	t.Cleanup(model.Close)
+
+	wallet := model.Wallet{
+		Name:        "bsc",
+		Status:      model.WaStatusEnable,
+		Address:     "0x0000000000000000000000000000000000000019",
+		MatchAddr:   "0x0000000000000000000000000000000000000019",
+		TradeType:   string(model.UsdtBep20),
+		OtherNotify: model.WaOtherEnable,
+	}
+	if err := model.Db.Create(&wallet).Error; err != nil {
+		t.Fatalf("create wallet: %v", err)
+	}
+
+	bad := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, `{"jsonrpc":"2.0","error":{"code":429,"message":"Too Many Requests"}}`, http.StatusTooManyRequests)
+	}))
+	defer bad.Close()
+
+	good := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":1,"result":"0x64"}`))
+	}))
+	defer good.Close()
+
+	model.SetK(model.RpcEndpointBsc, bad.URL+"\n"+good.URL)
+	model.RefreshC()
+
+	scanner := evm{
+		Network:        conf.Bsc,
+		Client:         bad.Client(),
+		blockScanQueue: chanx.NewUnboundedChan[evmBlock](context.Background(), 30),
+	}
+
+	scanner.syncBlocksForward(context.Background())
+
+	if got := model.Endpoint(conf.Bsc); got != good.URL {
+		t.Fatalf("expected active endpoint to rotate to %q, got %q", good.URL, got)
+	}
+}
+
+func TestEvmLatestBlockNumberFallsBackToNextEndpointImmediately(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "evm-latest-block-failover.db")
+	if err := model.Init(dbPath, "", ""); err != nil {
+		t.Fatalf("init test db: %v", err)
+	}
+	t.Cleanup(model.Close)
+
+	bad := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"jsonrpc":"2.0","error":{"code":429,"message":"Too Many Requests"}}`))
+	}))
+	defer bad.Close()
+
+	good := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":1,"result":"0x65"}`))
+	}))
+	defer good.Close()
+
+	model.SetK(model.RpcEndpointArbitrum, bad.URL+"\n"+good.URL)
+	model.RefreshC()
+
+	scanner := evm{
+		Network: conf.Arbitrum,
+		Client:  good.Client(),
+	}
+
+	got, err := scanner.latestBlockNumber(context.Background())
+	if err != nil {
+		t.Fatalf("expected fallback request to succeed, got error: %v", err)
+	}
+	if got != 101 {
+		t.Fatalf("expected latest block 101, got %d", got)
+	}
+	if active := model.Endpoint(conf.Arbitrum); active != good.URL {
+		t.Fatalf("expected active endpoint to be rotated to %q, got %q", good.URL, active)
+	}
+}

--- a/app/task/solana.go
+++ b/app/task/solana.go
@@ -505,9 +505,11 @@ func (s *solana) reconcileOrderTokenAccount(ctx context.Context, order model.Ord
 			continue
 		}
 
-		blockTime := sig.Get("blockTime").Int()
-		if blockTime > 0 {
-			ts := time.Unix(blockTime, 0)
+		signatureBlockTime := sig.Get("blockTime").Int()
+		signatureTimestamp := time.Time{}
+		if signatureBlockTime > 0 {
+			signatureTimestamp = time.Unix(signatureBlockTime, 0)
+			ts := signatureTimestamp
 			if !order.CreatedAt.Before(ts) || !order.ExpiredAt.After(ts) {
 				continue
 			}
@@ -536,7 +538,15 @@ func (s *solana) reconcileOrderTokenAccount(ctx context.Context, order model.Ord
 				t.BlockNum = int(result.Get("slot").Int())
 			}
 			if t.Timestamp.IsZero() {
-				t.Timestamp = time.Unix(result.Get("blockTime").Int(), 0)
+				t.Timestamp = signatureTimestamp
+			}
+			if t.Timestamp.IsZero() {
+				// Neither RPC result provided a trustworthy time, so this candidate
+				// cannot safely pass the order's payment window check.
+				continue
+			}
+			if !model.IsAmountValid(t.TradeType, t.Amount) {
+				continue
 			}
 			if !orderTransferMatch(order, t) {
 				continue
@@ -605,6 +615,12 @@ func parseSolanaParsedTransfers(tx gjson.Result) []transfer {
 		}
 	}
 
+	blockTime := tx.Get("blockTime").Int()
+	timestamp := time.Time{}
+	if blockTime > 0 {
+		timestamp = time.Unix(blockTime, 0)
+	}
+
 	transfers := make([]transfer, 0)
 	instructions := tx.Get("transaction.message.instructions").Array()
 	for _, inner := range tx.Get("meta.innerInstructions").Array() {
@@ -655,7 +671,7 @@ func parseSolanaParsedTransfers(tx gjson.Result) []transfer {
 			Amount:      decimal.NewFromBigInt(amountInt, -int32(decimals)),
 			FromAddress: from.Address,
 			RecvAddress: to.Address,
-			Timestamp:   time.Unix(tx.Get("blockTime").Int(), 0),
+			Timestamp:   timestamp,
 			TradeType:   from.TradeType,
 			BlockNum:    int(tx.Get("slot").Int()),
 		})

--- a/app/task/solana.go
+++ b/app/task/solana.go
@@ -4,8 +4,8 @@ import (
 	"bytes"
 	"context"
 	"encoding/binary"
+	"encoding/json"
 	"fmt"
-	"io"
 	"math/big"
 	"net/http"
 	"sync"
@@ -65,27 +65,22 @@ func (s *solana) syncSlotForward(ctx context.Context) {
 		return
 	}
 
-	req, _ := http.NewRequestWithContext(ctx, "POST", model.Endpoint(conf.Solana), bytes.NewBuffer([]byte(`{"jsonrpc":"2.0","id":1,"method":"getSlot"}`)))
-	req.Header.Set("Content-Type", "application/json")
-
-	resp, err := s.client.Do(req)
+	body, _, err := doRPCRequestWithFailover(ctx, s.client, conf.Solana, func(endpoint string) (*http.Request, error) {
+		req, err := http.NewRequestWithContext(ctx, "POST", endpoint, bytes.NewBuffer([]byte(`{"jsonrpc":"2.0","id":1,"method":"getSlot"}`)))
+		if err != nil {
+			return nil, err
+		}
+		req.Header.Set("Content-Type", "application/json")
+		return req, nil
+	}, func(body []byte) error {
+		data := gjson.ParseBytes(body)
+		if data.Get("error").Exists() {
+			return fmt.Errorf("%s", data.Get("error").String())
+		}
+		return nil
+	})
 	if err != nil {
-		log.Task.Warn("syncSlotForward Error sending request:", err)
-
-		return
-	}
-
-	defer resp.Body.Close()
-
-	if resp.StatusCode != 200 {
-		log.Task.Warn("syncSlotForward Error response status code:", resp.StatusCode)
-
-		return
-	}
-
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		log.Task.Warn("syncSlotForward Error reading response body:", err)
+		log.Task.Warn("syncSlotForward Error:", err)
 
 		return
 	}
@@ -96,6 +91,7 @@ func (s *solana) syncSlotForward(ctx context.Context) {
 
 		return
 	}
+	model.SetChainProgress(conf.Solana, now)
 
 	if now-s.lastSlotNum > cast.ToInt(model.GetC(model.BlockHeightMaxDiff)) { // 区块高度变化过大，强制丢块重扫
 		s.lastSlotNum = now
@@ -147,28 +143,27 @@ func (s *solana) slotParse(n any) {
 	post := []byte(fmt.Sprintf(`{"jsonrpc":"2.0","id":1,"method":"getBlock","params":[%d,{"encoding":"json","maxSupportedTransactionVersion":0,"transactionDetails":"full","rewards":false}]}`, slot))
 	network := conf.Solana
 
-	conf.RecordSuccess(network, cast.ToString(slot))
-	resp, err := s.client.Post(model.Endpoint(conf.Solana), "application/json", bytes.NewBuffer(post))
+	body, _, err := doRPCRequestWithFailover(context.Background(), s.client, network, func(endpoint string) (*http.Request, error) {
+		req, err := http.NewRequestWithContext(context.Background(), "POST", endpoint, bytes.NewBuffer(post))
+		if err != nil {
+			return nil, err
+		}
+		req.Header.Set("Content-Type", "application/json")
+		return req, nil
+	}, func(body []byte) error {
+		data := gjson.ParseBytes(body)
+		if data.Get("error").Exists() {
+			return fmt.Errorf("%s", data.Get("error").String())
+		}
+		result := data.Get("result")
+		if !result.Exists() || result.Raw == "null" {
+			return fmt.Errorf("slot %d block is temporarily unavailable", slot)
+		}
+		return nil
+	})
 	if err != nil {
-		conf.RecordFailure(network)
-		log.Task.Warn("slotParse Error sending request:", err)
-
-		return
-	}
-
-	defer resp.Body.Close()
-	if resp.StatusCode != 200 {
-		conf.RecordFailure(network)
-		log.Task.Warn("slotParse Error response status code:", resp.StatusCode)
-
-		return
-	}
-
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		conf.RecordFailure(network)
 		s.slotQueue.In <- slot
-		log.Task.Warn("slotParse Error reading response body:", err)
+		log.Task.Warn("slotParse Error:", err)
 
 		return
 	}
@@ -335,36 +330,27 @@ func (s *solana) tradeConfirmHandle(ctx context.Context) {
 		}
 
 		post := []byte(fmt.Sprintf(`{"jsonrpc":"2.0","id":1,"method":"getSignatureStatuses","params":[["%s"],{"searchTransactionHistory":true}]}`, o.RefHash))
-		req, _ := http.NewRequestWithContext(ctx, "POST", model.Endpoint(conf.Solana), bytes.NewBuffer(post))
-		resp, err := s.client.Do(req)
+		body, _, err := doRPCRequestWithFailover(ctx, s.client, conf.Solana, func(endpoint string) (*http.Request, error) {
+			req, err := http.NewRequestWithContext(ctx, "POST", endpoint, bytes.NewBuffer(post))
+			if err != nil {
+				return nil, err
+			}
+			req.Header.Set("Content-Type", "application/json")
+			return req, nil
+		}, func(body []byte) error {
+			data := gjson.ParseBytes(body)
+			if data.Get("error").Exists() {
+				return fmt.Errorf("%s", data.Get("error").String())
+			}
+			return nil
+		})
 		if err != nil {
-			log.Task.Warn("solana tradeConfirmHandle Error sending request:", err)
-
-			return
-		}
-
-		defer resp.Body.Close()
-
-		if resp.StatusCode != 200 {
-			log.Task.Warn("solana tradeConfirmHandle Error response status code:", resp.StatusCode)
-
-			return
-		}
-
-		body, err := io.ReadAll(resp.Body)
-		if err != nil {
-			log.Task.Warn("solana tradeConfirmHandle Error reading response body:", err)
+			log.Task.Warn("solana tradeConfirmHandle Error:", err)
 
 			return
 		}
 
 		data := gjson.ParseBytes(body)
-		if data.Get("error").Exists() {
-			log.Task.Warn("solana tradeConfirmHandle Error:", data.Get("error").String())
-
-			return
-		}
-
 		if data.Get("result.value.0.confirmationStatus").String() == "finalized" {
 
 			markFinalConfirmed(o)
@@ -388,6 +374,8 @@ func (s *solana) lookbackSlots(ctx context.Context) {
 		return
 	}
 
+	s.reconcileWaitingOrders(ctx)
+
 	startAt, endAt, ok := getLookbackUnix(conf.Solana)
 	if !ok {
 		return
@@ -406,4 +394,261 @@ func (s *solana) lookbackSlots(ctx context.Context) {
 		s.slotQueue.In <- i
 		time.Sleep(time.Millisecond * 200)
 	}
+}
+
+func (s *solana) reconcileWaitingOrders(ctx context.Context) {
+	trades := model.GetNetworkTrades(conf.Solana)
+	if len(trades) == 0 {
+		return
+	}
+
+	orders := make([]model.Order, 0)
+	model.Db.Where("status in (?) and trade_type in (?)", receivableOrderStatuses(), trades).
+		Where("expired_at > ?", time.Now().Add(model.GetLookbackHour())).
+		Order("created_at asc").
+		Find(&orders)
+	if len(orders) == 0 {
+		return
+	}
+
+	tokenAccounts := make(map[string][]string)
+	for _, order := range orders {
+		if ctx.Err() != nil {
+			return
+		}
+
+		address := orderMatchAddress(order)
+		key := fmt.Sprintf("%s%s", address, order.TradeType)
+		accounts, ok := tokenAccounts[key]
+		if !ok {
+			var err error
+			accounts, err = s.getTokenAccountsByOwner(ctx, address, order.TradeType)
+			if err != nil {
+				log.Task.Warn("solana reconcile getTokenAccountsByOwner Error:", err)
+				continue
+			}
+			tokenAccounts[key] = accounts
+		}
+
+		for _, account := range accounts {
+			if s.reconcileOrderTokenAccount(ctx, order, account) {
+				break
+			}
+		}
+	}
+}
+
+func (s *solana) getTokenAccountsByOwner(ctx context.Context, owner string, tradeType model.TradeType) ([]string, error) {
+	contract := ""
+	if c, ok := model.GetAllTradeConfig()[string(tradeType)]; ok {
+		contract = c.Contract
+	}
+	if contract == "" {
+		return nil, nil
+	}
+
+	result, err := s.rpc(ctx, "getTokenAccountsByOwner", []any{
+		owner,
+		map[string]any{"mint": contract},
+		map[string]any{"encoding": "jsonParsed"},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	accounts := make([]string, 0)
+	for _, item := range result.Get("value").Array() {
+		pubkey := item.Get("pubkey").String()
+		if pubkey != "" {
+			accounts = append(accounts, pubkey)
+		}
+	}
+
+	return accounts, nil
+}
+
+func (s *solana) reconcileOrderTokenAccount(ctx context.Context, order model.Order, account string) bool {
+	result, err := s.rpc(ctx, "getSignaturesForAddress", []any{
+		account,
+		map[string]any{"limit": 50},
+	})
+	if err != nil {
+		log.Task.Warn("solana reconcile getSignaturesForAddress Error:", err)
+		return false
+	}
+
+	for _, sig := range result.Array() {
+		if sig.Get("err").Exists() && sig.Get("err").Raw != "null" {
+			continue
+		}
+
+		blockTime := sig.Get("blockTime").Int()
+		if blockTime > 0 {
+			ts := time.Unix(blockTime, 0)
+			if !order.CreatedAt.Before(ts) || !order.ExpiredAt.After(ts) {
+				continue
+			}
+		}
+
+		hash := sig.Get("signature").String()
+		if hash == "" {
+			continue
+		}
+
+		result, err := s.rpc(ctx, "getTransaction", []any{
+			hash,
+			map[string]any{"encoding": "jsonParsed", "maxSupportedTransactionVersion": 0},
+		})
+		if err != nil {
+			log.Task.Warn("solana reconcile getTransaction Error:", err)
+			continue
+		}
+		if result.Get("meta.err").Exists() && result.Get("meta.err").Raw != "null" {
+			continue
+		}
+
+		for _, t := range parseSolanaParsedTransfers(result) {
+			t.TxHash = hash
+			if t.BlockNum == 0 {
+				t.BlockNum = int(result.Get("slot").Int())
+			}
+			if t.Timestamp.IsZero() {
+				t.Timestamp = time.Unix(result.Get("blockTime").Int(), 0)
+			}
+			if !orderTransferMatch(order, t) {
+				continue
+			}
+
+			if err := order.MarkConfirming(t.BlockNum, t.FromAddress, t.TxHash, t.Timestamp, t.Amount); err != nil {
+				log.Task.Warn("solana reconcile mark order confirming failed:", err)
+				return false
+			}
+
+			log.Task.Info(fmt.Sprintf("Solana 订单回查确认成功：%s %s", order.TradeId, t.TxHash))
+			return true
+		}
+	}
+
+	return false
+}
+
+func (s *solana) rpc(ctx context.Context, method string, params any) (gjson.Result, error) {
+	post, err := json.Marshal(map[string]any{
+		"jsonrpc": "2.0",
+		"id":      1,
+		"method":  method,
+		"params":  params,
+	})
+	if err != nil {
+		return gjson.Result{}, err
+	}
+
+	body, _, err := doRPCRequestWithFailover(ctx, s.client, conf.Solana, func(endpoint string) (*http.Request, error) {
+		req, err := http.NewRequestWithContext(ctx, "POST", endpoint, bytes.NewBuffer(post))
+		if err != nil {
+			return nil, err
+		}
+		req.Header.Set("Content-Type", "application/json")
+		return req, nil
+	}, func(body []byte) error {
+		data := gjson.ParseBytes(body)
+		if data.Get("error").Exists() {
+			return fmt.Errorf("%s", data.Get("error").String())
+		}
+		return nil
+	})
+	if err != nil {
+		return gjson.Result{}, err
+	}
+
+	data := gjson.ParseBytes(body)
+
+	return data.Get("result"), nil
+}
+
+func parseSolanaParsedTransfers(tx gjson.Result) []transfer {
+	tokenAccountMap := make(map[string]solanaTokenOwner)
+	for _, v := range []string{"postTokenBalances", "preTokenBalances"} {
+		for _, item := range tx.Get("meta." + v).Array() {
+			tradeType, ok := model.GetContractTrade(item.Get("mint").String())
+			if !ok || item.Get("programId").String() != conf.SolSplToken {
+				continue
+			}
+
+			tokenAccountMap[item.Get("accountIndex").String()] = solanaTokenOwner{
+				TradeType: tradeType,
+				Address:   item.Get("owner").String(),
+			}
+		}
+	}
+
+	transfers := make([]transfer, 0)
+	instructions := tx.Get("transaction.message.instructions").Array()
+	for _, inner := range tx.Get("meta.innerInstructions").Array() {
+		instructions = append(instructions, inner.Get("instructions").Array()...)
+	}
+
+	for _, instr := range instructions {
+		if instr.Get("programId").String() != conf.SolSplToken {
+			continue
+		}
+
+		parsed := instr.Get("parsed")
+		if !parsed.Exists() {
+			continue
+		}
+
+		typ := parsed.Get("type").String()
+		if typ != "transfer" && typ != "transferChecked" {
+			continue
+		}
+
+		info := parsed.Get("info")
+		source := info.Get("source").String()
+		destination := info.Get("destination").String()
+		from, ok := tokenAccountOwnerByPubkey(tx, tokenAccountMap, source)
+		if !ok {
+			continue
+		}
+		to, ok := tokenAccountOwnerByPubkey(tx, tokenAccountMap, destination)
+		if !ok {
+			continue
+		}
+
+		amountRaw := info.Get("tokenAmount.amount").String()
+		decimals := info.Get("tokenAmount.decimals").Int()
+		if amountRaw == "" {
+			amountRaw = info.Get("amount").String()
+			decimals = 6
+		}
+
+		amountInt, ok := new(big.Int).SetString(amountRaw, 10)
+		if !ok {
+			continue
+		}
+
+		transfers = append(transfers, transfer{
+			Network:     conf.Solana,
+			Amount:      decimal.NewFromBigInt(amountInt, -int32(decimals)),
+			FromAddress: from.Address,
+			RecvAddress: to.Address,
+			Timestamp:   time.Unix(tx.Get("blockTime").Int(), 0),
+			TradeType:   from.TradeType,
+			BlockNum:    int(tx.Get("slot").Int()),
+		})
+	}
+
+	return transfers
+}
+
+func tokenAccountOwnerByPubkey(tx gjson.Result, tokenAccountMap map[string]solanaTokenOwner, pubkey string) (solanaTokenOwner, bool) {
+	accountKeys := tx.Get("transaction.message.accountKeys").Array()
+	for i, key := range accountKeys {
+		if key.Get("pubkey").String() == pubkey || key.String() == pubkey {
+			owner, ok := tokenAccountMap[fmt.Sprintf("%d", i)]
+			return owner, ok
+		}
+	}
+
+	return solanaTokenOwner{}, false
 }

--- a/app/task/solana.go
+++ b/app/task/solana.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/binary"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"math/big"
 	"net/http"
@@ -41,6 +42,8 @@ type solanaTokenOwner struct {
 }
 
 var sol solana
+
+var errSolanaSlotSkipped = errors.New("solana slot was permanently skipped")
 
 func init() {
 	sol = newSolana()
@@ -152,8 +155,11 @@ func (s *solana) slotParse(n any) {
 		return req, nil
 	}, func(body []byte) error {
 		data := gjson.ParseBytes(body)
-		if data.Get("error").Exists() {
-			return fmt.Errorf("%s", data.Get("error").String())
+		if rpcErr := data.Get("error"); rpcErr.Exists() {
+			if rpcErr.Get("code").Int() == -32007 {
+				return terminalRPCError(fmt.Errorf("%w: %s", errSolanaSlotSkipped, rpcErr.Get("message").String()))
+			}
+			return fmt.Errorf("%s", rpcErr.String())
 		}
 		result := data.Get("result")
 		if !result.Exists() || result.Raw == "null" {
@@ -162,6 +168,10 @@ func (s *solana) slotParse(n any) {
 		return nil
 	})
 	if err != nil {
+		if errors.Is(err, errSolanaSlotSkipped) {
+			log.Task.Info(fmt.Sprintf("Solana 跳过永久缺失 Slot：%d", slot))
+			return
+		}
 		s.slotQueue.In <- slot
 		log.Task.Warn("slotParse Error:", err)
 

--- a/app/task/solana.go
+++ b/app/task/solana.go
@@ -181,6 +181,12 @@ func (s *solana) slotParse(n any) {
 	timestamp := time.Unix(gjson.GetBytes(body, "result.blockTime").Int(), 0)
 
 	for _, trans := range gjson.GetBytes(body, "result.transactions").Array() {
+		// A failed transaction can still retain parsed SPL instructions and token
+		// balances in getBlock. It must never reach the generic transfer matcher.
+		if txErr := trans.Get("meta.err"); txErr.Exists() && txErr.Raw != "null" {
+			continue
+		}
+
 		hash := trans.Get("transaction.signatures.0").String()
 
 		// 解析账号索引
@@ -361,7 +367,14 @@ func (s *solana) tradeConfirmHandle(ctx context.Context) {
 		}
 
 		data := gjson.ParseBytes(body)
-		if data.Get("result.value.0.confirmationStatus").String() == "finalized" {
+		status := data.Get("result.value.0")
+		// Solana finalizes both successful and failed transactions. The status
+		// must therefore be finalized *and* have a null execution error before
+		// an order can become successful or trigger a merchant callback.
+		if txErr := status.Get("err"); txErr.Exists() && txErr.Raw != "null" {
+			return
+		}
+		if status.Get("confirmationStatus").String() == "finalized" {
 
 			markFinalConfirmed(o)
 		}

--- a/app/task/solana_reconcile_test.go
+++ b/app/task/solana_reconcile_test.go
@@ -1,0 +1,351 @@
+package task
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"github.com/tidwall/gjson"
+	"github.com/v03413/bepusdt/app/log"
+	"github.com/v03413/bepusdt/app/model"
+)
+
+const (
+	testSolanaOwner       = "DAzEQJ8TzdmrAgphrcGGZie4fwiXmRYXRCKX4wQh2oLf"
+	testSolanaTokenWallet = "23PXKLkUNQ85LScKDZVWhHLzFppYiSVky2Z7iqkk4JFu"
+	testSolanaSender      = "5tzFkiKscXHK5ZXCGbXZxdw7gTjjD1mBwuoFbhUvuAi9"
+	testSolanaTxHash      = "3uhzPPDFKz8JTWJTPN2D7VbDTL94KXw2WyqEUvpLvbcsKVymDKETfMgwUxGsWM2tBDvteTHSRNZPU3Cx8u2hyMbe"
+)
+
+func TestSolanaReconcileWaitingOrdersMarksMatchingOrderConfirming(t *testing.T) {
+	initSolanaReconcileTestLog(t)
+
+	dbPath := filepath.Join(t.TempDir(), "solana-reconcile.db")
+	if err := model.Init(dbPath, "", ""); err != nil {
+		t.Fatalf("init test db: %v", err)
+	}
+	t.Cleanup(model.Close)
+
+	blockTime := time.Now().Add(-10 * time.Minute).Unix()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer r.Body.Close()
+
+		var req map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("decode rpc request: %v", err)
+		}
+
+		method, _ := req["method"].(string)
+		switch method {
+		case "getTokenAccountsByOwner":
+			_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":1,"result":{"value":[{"pubkey":"` + testSolanaTokenWallet + `"}]}}`))
+		case "getSignaturesForAddress":
+			_, _ = w.Write([]byte(fmt.Sprintf(`{"jsonrpc":"2.0","id":1,"result":[{"signature":"%s","slot":424729879,"err":null,"blockTime":%d}]}`, testSolanaTxHash, blockTime)))
+		case "getTransaction":
+			_, _ = w.Write([]byte(fmt.Sprintf(`{
+				"jsonrpc":"2.0",
+				"id":1,
+				"result":{
+					"slot":424729879,
+					"blockTime":%d,
+					"meta":{
+						"err":null,
+						"preTokenBalances":[
+							{"accountIndex":2,"mint":"EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v","owner":"`+testSolanaSender+`","programId":"TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"},
+							{"accountIndex":3,"mint":"EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v","owner":"`+testSolanaOwner+`","programId":"TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"}
+						],
+						"postTokenBalances":[
+							{"accountIndex":2,"mint":"EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v","owner":"`+testSolanaSender+`","programId":"TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"},
+							{"accountIndex":3,"mint":"EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v","owner":"`+testSolanaOwner+`","programId":"TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"}
+						],
+						"innerInstructions":[]
+					},
+					"transaction":{
+						"message":{
+							"accountKeys":[
+								{"pubkey":"`+testSolanaSender+`"},
+								{"pubkey":"13gxbc8s6rPLDXPMiTnbnKD6uVdddzKpUCBZA5iCmZkd"},
+								{"pubkey":"7KJjY7rArbydeLBF7gQ5LdqXRKRYyPArT99NEctsHsgU"},
+								{"pubkey":"`+testSolanaTokenWallet+`"}
+							],
+							"instructions":[
+								{
+									"program":"spl-token",
+									"programId":"TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+									"parsed":{
+										"type":"transferChecked",
+										"info":{
+											"authority":"`+testSolanaSender+`",
+											"source":"7KJjY7rArbydeLBF7gQ5LdqXRKRYyPArT99NEctsHsgU",
+											"destination":"`+testSolanaTokenWallet+`",
+											"mint":"EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+											"tokenAmount":{"amount":"13190000","decimals":6,"uiAmount":13.19,"uiAmountString":"13.19"}
+										}
+									}
+								}
+							]
+						}
+					}
+				}
+			}`, blockTime)))
+		default:
+			t.Fatalf("unexpected rpc method: %s", method)
+		}
+	}))
+	defer server.Close()
+
+	model.SetK(model.RpcEndpointSolana, server.URL)
+
+	createdAtTime := time.Unix(blockTime-6*60, 0)
+	expiredAt := time.Unix(blockTime+24*60, 0)
+	createdAt := model.Datetime(createdAtTime)
+	zero := time.Unix(0, 0)
+	order := model.Order{
+		OrderId:     "sub2_20260607ef8AeiFK",
+		TradeId:     "csxMKKMccWtlbGWg2Y",
+		TradeType:   model.UsdcSolana,
+		Crypto:      model.USDC,
+		Amount:      "13.19",
+		Money:       "100",
+		Address:     testSolanaOwner,
+		Status:      model.OrderStatusWaiting,
+		NotifyUrl:   "https://example.com/webhook",
+		ConfirmedAt: &zero,
+		ExpiredAt:   expiredAt,
+		AutoTimeAt: model.AutoTimeAt{
+			CreatedAt: &createdAt,
+			UpdatedAt: &createdAt,
+		},
+	}
+	if err := model.Db.Create(&order).Error; err != nil {
+		t.Fatalf("create order: %v", err)
+	}
+
+	s := newSolana()
+	s.client = server.Client()
+	s.reconcileWaitingOrders(context.Background())
+
+	var refreshed model.Order
+	if err := model.Db.First(&refreshed, order.ID).Error; err != nil {
+		t.Fatalf("reload order: %v", err)
+	}
+
+	if refreshed.Status != model.OrderStatusConfirming {
+		t.Fatalf("expected status %d, got %d", model.OrderStatusConfirming, refreshed.Status)
+	}
+	if refreshed.RefHash != testSolanaTxHash {
+		t.Fatalf("expected ref hash %s, got %s", testSolanaTxHash, refreshed.RefHash)
+	}
+	if refreshed.FromAddress != testSolanaSender {
+		t.Fatalf("expected from address %s, got %s", testSolanaSender, refreshed.FromAddress)
+	}
+	if refreshed.ConfirmedAt == nil {
+		t.Fatal("expected confirmed_at to be set")
+	}
+	if got := refreshed.ConfirmedAt.Unix(); got != blockTime {
+		t.Fatalf("expected confirmed_at unix %d, got %d", blockTime, got)
+	}
+}
+
+func initSolanaReconcileTestLog(t *testing.T) {
+	t.Helper()
+
+	logger := logrus.New()
+	logger.SetOutput(io.Discard)
+	log.Task = logger
+}
+
+func TestSolanaParsedTransactionProducesMatchingTransfer(t *testing.T) {
+	tx := gjson.Parse(`{
+		"blockTime":1780769985,
+		"meta":{
+			"preTokenBalances":[
+				{"accountIndex":2,"mint":"EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v","owner":"` + testSolanaSender + `","programId":"TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"},
+				{"accountIndex":3,"mint":"EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v","owner":"` + testSolanaOwner + `","programId":"TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"}
+			],
+			"postTokenBalances":[
+				{"accountIndex":2,"mint":"EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v","owner":"` + testSolanaSender + `","programId":"TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"},
+				{"accountIndex":3,"mint":"EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v","owner":"` + testSolanaOwner + `","programId":"TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"}
+			],
+			"innerInstructions":[]
+		},
+		"transaction":{
+			"message":{
+				"accountKeys":[
+					{"pubkey":"` + testSolanaSender + `"},
+					{"pubkey":"13gxbc8s6rPLDXPMiTnbnKD6uVdddzKpUCBZA5iCmZkd"},
+					{"pubkey":"7KJjY7rArbydeLBF7gQ5LdqXRKRYyPArT99NEctsHsgU"},
+					{"pubkey":"` + testSolanaTokenWallet + `"}
+				],
+				"instructions":[
+					{
+						"program":"spl-token",
+						"programId":"TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+						"parsed":{
+							"type":"transferChecked",
+							"info":{
+								"authority":"` + testSolanaSender + `",
+								"source":"7KJjY7rArbydeLBF7gQ5LdqXRKRYyPArT99NEctsHsgU",
+								"destination":"` + testSolanaTokenWallet + `",
+								"mint":"EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+								"tokenAmount":{"amount":"13190000","decimals":6,"uiAmount":13.19,"uiAmountString":"13.19"}
+							}
+						}
+					}
+				]
+			}
+		}
+	}`)
+
+	transfers := parseSolanaParsedTransfers(tx)
+	if len(transfers) != 1 {
+		t.Fatalf("expected 1 transfer, got %d", len(transfers))
+	}
+
+	got := transfers[0]
+	if got.TradeType != model.UsdcSolana {
+		t.Fatalf("expected trade type %s, got %s", model.UsdcSolana, got.TradeType)
+	}
+	if got.FromAddress != testSolanaSender {
+		t.Fatalf("expected from %s, got %s", testSolanaSender, got.FromAddress)
+	}
+	if got.RecvAddress != testSolanaOwner {
+		t.Fatalf("expected recv %s, got %s", testSolanaOwner, got.RecvAddress)
+	}
+	if got.Amount.String() != "13.19" {
+		t.Fatalf("expected amount 13.19, got %s", got.Amount.String())
+	}
+	if got.Timestamp.Unix() != 1780769985 {
+		t.Fatalf("expected timestamp 1780769985, got %d", got.Timestamp.Unix())
+	}
+}
+
+func TestSolanaSlotParseRequeuesWhenRPCBlockIsTemporarilyUnavailable(t *testing.T) {
+	initSolanaReconcileTestLog(t)
+
+	dbPath := filepath.Join(t.TempDir(), "solana-null-block.db")
+	if err := model.Init(dbPath, "", ""); err != nil {
+		t.Fatalf("init test db: %v", err)
+	}
+	t.Cleanup(model.Close)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":1,"result":null}`))
+	}))
+	defer server.Close()
+
+	model.SetK(model.RpcEndpointSolana, server.URL)
+	model.RefreshC()
+
+	const slot = 435577393
+	s := newSolana()
+	s.client = server.Client()
+	s.slotParse(slot)
+
+	select {
+	case got := <-s.slotQueue.Out:
+		if got != slot {
+			t.Fatalf("expected slot %d to be requeued, got %d", slot, got)
+		}
+	case <-time.After(time.Second):
+		t.Fatalf("expected temporarily unavailable slot %d to be requeued", slot)
+	}
+}
+
+func TestSolanaParseTransferRecognizesReportedTransaction(t *testing.T) {
+	accountKeys := []string{
+		"H1NwZnujLy6q2q9Mj813xCMSzkmYE6p6PzyC2zswJSmK",
+		"39YTZW8PKvvrcmtmWncD9V8viWjJMG57XeKf283jhnwy",
+		"9i5mDNaBqgjojBMpChrWbfCrD4hkBkgmyrvi8AFb9qHr",
+		"ComputeBudget111111111111111111111111111111",
+		"Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB",
+		"TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+	}
+	tokenAccounts := map[string]solanaTokenOwner{
+		accountKeys[1]: {
+			TradeType: model.UsdtSolana,
+			Address:   "H1NwZnujLy6q2q9Mj813xCMSzkmYE6p6PzyC2zswJSmK",
+		},
+		accountKeys[2]: {
+			TradeType: model.UsdtSolana,
+			Address:   "DAzEQJ8TzdmrAgphrcGGZie4fwiXmRYXRCKX4wQh2oLf",
+		},
+	}
+	instruction := gjson.Parse(`{
+		"accounts":[1,4,2,0],
+		"data":"gvJRrNPqACL1K",
+		"programIdIndex":5
+	}`)
+
+	s := newSolana()
+	got := s.parseTransfer(instruction, accountKeys, tokenAccounts)
+
+	if got.TradeType != model.UsdtSolana {
+		t.Fatalf("expected trade type %s, got %s", model.UsdtSolana, got.TradeType)
+	}
+	if got.FromAddress != "H1NwZnujLy6q2q9Mj813xCMSzkmYE6p6PzyC2zswJSmK" {
+		t.Fatalf("unexpected sender: %s", got.FromAddress)
+	}
+	if got.RecvAddress != "DAzEQJ8TzdmrAgphrcGGZie4fwiXmRYXRCKX4wQh2oLf" {
+		t.Fatalf("unexpected recipient: %s", got.RecvAddress)
+	}
+	if got.Amount.String() != "1.32" {
+		t.Fatalf("expected amount 1.32, got %s", got.Amount)
+	}
+}
+
+func TestGetConfirmingOrdersKeepsOnTimePaymentAfterOrderExpires(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "confirming-after-expire.db")
+	if err := model.Init(dbPath, "", ""); err != nil {
+		t.Fatalf("init test db: %v", err)
+	}
+	t.Cleanup(model.Close)
+
+	createdAt := model.Datetime(time.Now().Add(-2 * time.Hour))
+	confirmedAt := time.Now().Add(-90 * time.Minute)
+	expiredAt := time.Now().Add(-1 * time.Hour)
+	order := model.Order{
+		OrderId:       "late-finalized",
+		TradeId:       "late-finalized-trade",
+		TradeType:     model.UsdcSolana,
+		Crypto:        model.USDC,
+		Amount:        "13.19",
+		Money:         "100",
+		Address:       testSolanaOwner,
+		Status:        model.OrderStatusConfirming,
+		RefHash:       testSolanaTxHash,
+		RefBlockNum:   424729879,
+		NotifyUrl:     "https://example.com/webhook",
+		ConfirmedAt:   &confirmedAt,
+		ExpiredAt:     expiredAt,
+		AddressLocked: false,
+		AutoTimeAt: model.AutoTimeAt{
+			CreatedAt: &createdAt,
+			UpdatedAt: &createdAt,
+		},
+	}
+	if err := model.Db.Create(&order).Error; err != nil {
+		t.Fatalf("create order: %v", err)
+	}
+
+	orders := getConfirmingOrders([]model.TradeType{model.UsdcSolana})
+	if len(orders) != 1 {
+		t.Fatalf("expected confirming order to remain eligible, got %d", len(orders))
+	}
+
+	var refreshed model.Order
+	if err := model.Db.First(&refreshed, order.ID).Error; err != nil {
+		t.Fatalf("reload order: %v", err)
+	}
+	if refreshed.Status != model.OrderStatusConfirming {
+		t.Fatalf("expected status %d, got %d", model.OrderStatusConfirming, refreshed.Status)
+	}
+}

--- a/app/task/solana_reconcile_test.go
+++ b/app/task/solana_reconcile_test.go
@@ -299,6 +299,116 @@ func TestSolanaSlotParseDoesNotRequeuePermanentlySkippedSlot(t *testing.T) {
 	}
 }
 
+func TestSolanaSlotParseSkipsFailedTransactions(t *testing.T) {
+	initSolanaReconcileTestLog(t)
+
+	if err := model.Init(filepath.Join(t.TempDir(), "solana-failed-slot.db"), "", ""); err != nil {
+		t.Fatalf("init test db: %v", err)
+	}
+	t.Cleanup(model.Close)
+
+	blockTime := time.Now().Add(-time.Minute).Unix()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(fmt.Sprintf(`{
+			"jsonrpc":"2.0",
+			"id":1,
+			"result":{
+				"blockTime":%d,
+				"transactions":[{
+					"meta":{
+						"err":{"InstructionError":[0,"Custom"]},
+						"preTokenBalances":[
+							{"accountIndex":1,"mint":"Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB","owner":"%s","programId":"TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"},
+							{"accountIndex":2,"mint":"Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB","owner":"%s","programId":"TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"}
+						],
+						"postTokenBalances":[
+							{"accountIndex":1,"mint":"Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB","owner":"%s","programId":"TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"},
+							{"accountIndex":2,"mint":"Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB","owner":"%s","programId":"TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"}
+						],
+						"innerInstructions":[]
+					},
+					"transaction":{
+						"signatures":["%s"],
+						"message":{
+							"accountKeys":["%s","source-token-account","destination-token-account","ComputeBudget111111111111111111111111111111","Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB","TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"],
+							"instructions":[{"programIdIndex":5,"accounts":[1,4,2,0],"data":"gvJRrNPqACL1K"}]
+						}
+					}
+				}]
+			}
+		}`, blockTime, testSolanaSender, testSolanaOwner, testSolanaSender, testSolanaOwner, testSolanaTxHash, testSolanaSender)))
+	}))
+	defer server.Close()
+
+	model.SetK(model.RpcEndpointSolana, server.URL)
+	model.RefreshC()
+
+	s := newSolana()
+	s.client = server.Client()
+	s.slotParse(435577393)
+
+	select {
+	case queued := <-transferQueue.Out:
+		t.Fatalf("failed Solana transaction must not enter the transfer queue: %+v", queued)
+	case <-time.After(100 * time.Millisecond):
+	}
+}
+
+func TestSolanaTradeConfirmHandleDoesNotFinalizeFailedTransaction(t *testing.T) {
+	initSolanaReconcileTestLog(t)
+
+	if err := model.Init(filepath.Join(t.TempDir(), "solana-failed-confirmation.db"), "", ""); err != nil {
+		t.Fatalf("init test db: %v", err)
+	}
+	t.Cleanup(model.Close)
+
+	now := time.Now().UTC()
+	confirmedAt := now.Add(-time.Minute)
+	createdAt := model.Datetime(now.Add(-2 * time.Minute))
+	order := model.Order{
+		OrderId:     "failed-solana-confirmation",
+		TradeId:     "failed-solana-confirmation-trade",
+		TradeType:   model.UsdcSolana,
+		Crypto:      model.USDC,
+		Amount:      "2.65",
+		Money:       "20",
+		Address:     testSolanaOwner,
+		Status:      model.OrderStatusConfirming,
+		RefHash:     testSolanaTxHash,
+		RefBlockNum: 424729879,
+		ConfirmedAt: &confirmedAt,
+		ExpiredAt:   now.Add(time.Hour),
+		AutoTimeAt: model.AutoTimeAt{
+			CreatedAt: &createdAt,
+			UpdatedAt: &createdAt,
+		},
+	}
+	if err := model.Db.Create(&order).Error; err != nil {
+		t.Fatalf("create confirming order: %v", err)
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":1,"result":{"value":[{"slot":424729879,"confirmationStatus":"finalized","err":{"InstructionError":[0,"Custom"]}}]}}`))
+	}))
+	defer server.Close()
+
+	model.SetK(model.RpcEndpointSolana, server.URL)
+	model.SetK(model.BlockOffsetConfirm, "0")
+	model.RefreshC()
+
+	s := newSolana()
+	s.client = server.Client()
+	s.tradeConfirmHandle(context.Background())
+
+	var refreshed model.Order
+	if err := model.Db.First(&refreshed, order.ID).Error; err != nil {
+		t.Fatalf("reload order: %v", err)
+	}
+	if refreshed.Status != model.OrderStatusConfirming {
+		t.Fatalf("failed finalized Solana transaction changed order status to %d, want confirming", refreshed.Status)
+	}
+}
+
 func TestSolanaParseTransferRecognizesReportedTransaction(t *testing.T) {
 	accountKeys := []string{
 		"H1NwZnujLy6q2q9Mj813xCMSzkmYE6p6PzyC2zswJSmK",

--- a/app/task/solana_reconcile_test.go
+++ b/app/task/solana_reconcile_test.go
@@ -155,6 +155,196 @@ func TestSolanaReconcileWaitingOrdersMarksMatchingOrderConfirming(t *testing.T) 
 	}
 }
 
+func TestSolanaReconcileRejectsBelowMinimumAmountForAddressLockedOrder(t *testing.T) {
+	initSolanaReconcileTestLog(t)
+
+	if err := model.Init(filepath.Join(t.TempDir(), "solana-reconcile-low-amount.db"), "", ""); err != nil {
+		t.Fatalf("init test db: %v", err)
+	}
+	t.Cleanup(model.Close)
+
+	blockTime := time.Now().Add(-time.Minute).Unix()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer r.Body.Close()
+
+		var req map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("decode rpc request: %v", err)
+		}
+
+		switch req["method"] {
+		case "getSignaturesForAddress":
+			_, _ = w.Write([]byte(fmt.Sprintf(`{"jsonrpc":"2.0","id":1,"result":[{"signature":"%s","slot":424729879,"err":null,"blockTime":%d}]}`, testSolanaTxHash, blockTime)))
+		case "getTransaction":
+			_, _ = w.Write([]byte(fmt.Sprintf(`{
+				"jsonrpc":"2.0",
+				"id":1,
+				"result":{
+					"slot":424729879,
+					"blockTime":%d,
+					"meta":{
+						"err":null,
+						"preTokenBalances":[
+							{"accountIndex":2,"mint":"EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v","owner":"%s","programId":"TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"},
+							{"accountIndex":3,"mint":"EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v","owner":"%s","programId":"TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"}
+						],
+						"postTokenBalances":[
+							{"accountIndex":2,"mint":"EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v","owner":"%s","programId":"TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"},
+							{"accountIndex":3,"mint":"EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v","owner":"%s","programId":"TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"}
+						],
+						"innerInstructions":[]
+					},
+					"transaction":{"message":{
+						"accountKeys":[
+							{"pubkey":"%s"},
+							{"pubkey":"13gxbc8s6rPLDXPMiTnbnKD6uVdddzKpUCBZA5iCmZkd"},
+							{"pubkey":"7KJjY7rArbydeLBF7gQ5LdqXRKRYyPArT99NEctsHsgU"},
+							{"pubkey":"%s"}
+						],
+						"instructions":[{"program":"spl-token","programId":"TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA","parsed":{"type":"transferChecked","info":{"source":"7KJjY7rArbydeLBF7gQ5LdqXRKRYyPArT99NEctsHsgU","destination":"%s","tokenAmount":{"amount":"1000","decimals":6}}}}]
+					}}
+				}
+			}`, blockTime, testSolanaSender, testSolanaOwner, testSolanaSender, testSolanaOwner, testSolanaSender, testSolanaTokenWallet, testSolanaTokenWallet)))
+		default:
+			t.Fatalf("unexpected rpc method: %v", req["method"])
+		}
+	}))
+	defer server.Close()
+
+	model.SetK(model.RpcEndpointSolana, server.URL)
+	model.RefreshC()
+
+	createdAtTime := time.Unix(blockTime-30, 0)
+	createdAt := model.Datetime(createdAtTime)
+	zero := time.Unix(0, 0)
+	order := model.Order{
+		OrderId:       "solana-low-amount",
+		TradeId:       "solana-low-amount-trade",
+		TradeType:     model.UsdcSolana,
+		Crypto:        model.USDC,
+		Amount:        "0",
+		Money:         "0",
+		Address:       testSolanaOwner,
+		AddressLocked: true,
+		Status:        model.OrderStatusWaiting,
+		ConfirmedAt:   &zero,
+		ExpiredAt:     time.Unix(blockTime+30, 0),
+		AutoTimeAt: model.AutoTimeAt{
+			CreatedAt: &createdAt,
+			UpdatedAt: &createdAt,
+		},
+	}
+	if err := model.Db.Create(&order).Error; err != nil {
+		t.Fatalf("create address-locked order: %v", err)
+	}
+
+	s := newSolana()
+	s.client = server.Client()
+	if s.reconcileOrderTokenAccount(context.Background(), order, testSolanaTokenWallet) {
+		t.Fatal("below-minimum Solana transfer must not reconcile an address-locked order")
+	}
+
+	var refreshed model.Order
+	if err := model.Db.First(&refreshed, order.ID).Error; err != nil {
+		t.Fatalf("reload order: %v", err)
+	}
+	if refreshed.Status != model.OrderStatusWaiting {
+		t.Fatalf("below-minimum Solana transfer changed order status to %d, want waiting", refreshed.Status)
+	}
+}
+
+func TestSolanaReconcileUsesSignatureTimeWhenTransactionBlockTimeIsMissing(t *testing.T) {
+	initSolanaReconcileTestLog(t)
+
+	if err := model.Init(filepath.Join(t.TempDir(), "solana-reconcile-signature-time.db"), "", ""); err != nil {
+		t.Fatalf("init test db: %v", err)
+	}
+	t.Cleanup(model.Close)
+
+	blockTime := time.Now().Add(-time.Minute).Unix()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer r.Body.Close()
+
+		var req map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("decode rpc request: %v", err)
+		}
+
+		switch req["method"] {
+		case "getSignaturesForAddress":
+			_, _ = w.Write([]byte(fmt.Sprintf(`{"jsonrpc":"2.0","id":1,"result":[{"signature":"%s","slot":424729879,"err":null,"blockTime":%d}]}`, testSolanaTxHash, blockTime)))
+		case "getTransaction":
+			_, _ = w.Write([]byte(fmt.Sprintf(`{
+				"jsonrpc":"2.0",
+				"id":1,
+				"result":{
+					"slot":424729879,
+					"blockTime":null,
+					"meta":{
+						"err":null,
+						"preTokenBalances":[
+							{"accountIndex":0,"mint":"EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v","owner":"%s","programId":"TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"},
+							{"accountIndex":1,"mint":"EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v","owner":"%s","programId":"TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"}
+						],
+						"postTokenBalances":[],
+						"innerInstructions":[]
+					},
+					"transaction":{"message":{
+						"accountKeys":[{"pubkey":"source-token-account"},{"pubkey":"%s"}],
+						"instructions":[{"program":"spl-token","programId":"TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA","parsed":{"type":"transferChecked","info":{"source":"source-token-account","destination":"%s","tokenAmount":{"amount":"2650000","decimals":6}}}}]
+					}}
+				}
+			}`, testSolanaSender, testSolanaOwner, testSolanaTokenWallet, testSolanaTokenWallet)))
+		default:
+			t.Fatalf("unexpected rpc method: %v", req["method"])
+		}
+	}))
+	defer server.Close()
+
+	model.SetK(model.RpcEndpointSolana, server.URL)
+	model.RefreshC()
+
+	createdAtTime := time.Unix(blockTime-30, 0)
+	createdAt := model.Datetime(createdAtTime)
+	zero := time.Unix(0, 0)
+	order := model.Order{
+		OrderId:     "solana-signature-time",
+		TradeId:     "solana-signature-time-trade",
+		TradeType:   model.UsdcSolana,
+		Crypto:      model.USDC,
+		Amount:      "2.65",
+		Money:       "20",
+		Address:     testSolanaOwner,
+		Status:      model.OrderStatusWaiting,
+		ConfirmedAt: &zero,
+		ExpiredAt:   time.Unix(blockTime+30, 0),
+		AutoTimeAt: model.AutoTimeAt{
+			CreatedAt: &createdAt,
+			UpdatedAt: &createdAt,
+		},
+	}
+	if err := model.Db.Create(&order).Error; err != nil {
+		t.Fatalf("create order: %v", err)
+	}
+
+	s := newSolana()
+	s.client = server.Client()
+	if !s.reconcileOrderTokenAccount(context.Background(), order, testSolanaTokenWallet) {
+		t.Fatal("reconcile should use the signature-list block time when getTransaction omits it")
+	}
+
+	var refreshed model.Order
+	if err := model.Db.First(&refreshed, order.ID).Error; err != nil {
+		t.Fatalf("reload order: %v", err)
+	}
+	if refreshed.Status != model.OrderStatusConfirming {
+		t.Fatalf("missing getTransaction block time left order status %d, want confirming", refreshed.Status)
+	}
+	if refreshed.ConfirmedAt == nil || refreshed.ConfirmedAt.Unix() != blockTime {
+		t.Fatalf("confirmed_at = %v, want signature-list block time %d", refreshed.ConfirmedAt, blockTime)
+	}
+}
+
 func initSolanaReconcileTestLog(t *testing.T) {
 	t.Helper()
 

--- a/app/task/solana_reconcile_test.go
+++ b/app/task/solana_reconcile_test.go
@@ -260,6 +260,45 @@ func TestSolanaSlotParseRequeuesWhenRPCBlockIsTemporarilyUnavailable(t *testing.
 	}
 }
 
+func TestSolanaSlotParseDoesNotRequeuePermanentlySkippedSlot(t *testing.T) {
+	initSolanaReconcileTestLog(t)
+
+	dbPath := filepath.Join(t.TempDir(), "solana-skipped-slot.db")
+	if err := model.Init(dbPath, "", ""); err != nil {
+		t.Fatalf("init test db: %v", err)
+	}
+	t.Cleanup(model.Close)
+
+	skipped := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":1,"error":{"code":-32007,"message":"Slot 436683136 was skipped, or missing due to ledger jump to recent snapshot"}}`))
+	}))
+	defer skipped.Close()
+
+	rateLimitedCalls := 0
+	rateLimited := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		rateLimitedCalls++
+		_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":1,"error":{"code":-32005,"message":"rate limit exceeded"}}`))
+	}))
+	defer rateLimited.Close()
+
+	model.SetK(model.RpcEndpointSolana, skipped.URL+","+rateLimited.URL)
+	model.RefreshC()
+
+	const slot = 436683136
+	s := newSolana()
+	s.client = skipped.Client()
+	s.slotParse(slot)
+
+	select {
+	case got := <-s.slotQueue.Out:
+		t.Fatalf("permanently skipped slot must not be requeued, got %d", got)
+	case <-time.After(100 * time.Millisecond):
+	}
+	if rateLimitedCalls != 0 {
+		t.Fatalf("permanently skipped slot must not fail over, second endpoint called %d times", rateLimitedCalls)
+	}
+}
+
 func TestSolanaParseTransferRecognizesReportedTransaction(t *testing.T) {
 	accountKeys := []string{
 		"H1NwZnujLy6q2q9Mj813xCMSzkmYE6p6PzyC2zswJSmK",
@@ -299,6 +338,48 @@ func TestSolanaParseTransferRecognizesReportedTransaction(t *testing.T) {
 	}
 	if got.Amount.String() != "1.32" {
 		t.Fatalf("expected amount 1.32, got %s", got.Amount)
+	}
+}
+
+func TestSolanaParseTransferRecognizesReportedMultisigUSDCTransaction(t *testing.T) {
+	accountKeys := []string{
+		"BhJuSLM8WzkM71umK4UQXXRfVB4ZoHbaDsEQercc2eMX",
+		"23PXKLkUNQ85LScKDZVWhHLzFppYiSVky2Z7iqkk4JFu",
+		"8w7MbgKz4mRu2Ku9KS2JQ519mZfX4fgiN6qrjdEuAG8H",
+		"ComputeBudget111111111111111111111111111111",
+		"EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+		"TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+	}
+	tokenAccounts := map[string]solanaTokenOwner{
+		accountKeys[1]: {
+			TradeType: model.UsdcSolana,
+			Address:   "DAzEQJ8TzdmrAgphrcGGZie4fwiXmRYXRCKX4wQh2oLf",
+		},
+		accountKeys[2]: {
+			TradeType: model.UsdcSolana,
+			Address:   "BhJuSLM8WzkM71umK4UQXXRfVB4ZoHbaDsEQercc2eMX",
+		},
+	}
+	instruction := gjson.Parse(`{
+		"accounts":[2,4,1,0,0],
+		"data":"hwaXrj5gCKML9",
+		"programIdIndex":5
+	}`)
+
+	s := newSolana()
+	got := s.parseTransfer(instruction, accountKeys, tokenAccounts)
+
+	if got.TradeType != model.UsdcSolana {
+		t.Fatalf("expected trade type %s, got %s", model.UsdcSolana, got.TradeType)
+	}
+	if got.FromAddress != "BhJuSLM8WzkM71umK4UQXXRfVB4ZoHbaDsEQercc2eMX" {
+		t.Fatalf("unexpected sender: %s", got.FromAddress)
+	}
+	if got.RecvAddress != "DAzEQJ8TzdmrAgphrcGGZie4fwiXmRYXRCKX4wQh2oLf" {
+		t.Fatalf("unexpected recipient: %s", got.RecvAddress)
+	}
+	if got.Amount.String() != "2.65" {
+		t.Fatalf("expected amount 2.65, got %s", got.Amount)
 	}
 }
 

--- a/app/task/transfer.go
+++ b/app/task/transfer.go
@@ -2,6 +2,7 @@ package task
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"sync"
@@ -85,7 +86,16 @@ func orderTransferHandle(ctx context.Context) {
 			}
 
 			var other = make([]transfer, 0)
-			var orders = getReceivableOrders()
+			orders, err := getReceivableOrders()
+			if err != nil {
+				// A transient database read failure must never turn valid payments
+				// into non-order transfers. Keep the batch for the next retry.
+				log.Task.Warn("load receivable orders failed; retaining transfer batch:", err)
+				if shouldCheck {
+					expireWaitingOrders()
+				}
+				continue
+			}
 
 			for _, t := range batch {
 				// 判断数额是否在允许范围内
@@ -95,21 +105,40 @@ func orderTransferHandle(ctx context.Context) {
 
 				mqttPublish(t)
 
-				key := fmt.Sprintf("%s%s", t.RecvAddress, t.TradeType)
+				key := orderTransferKey(t.RecvAddress, t.TradeType)
 				orderList, ok := orders[key]
 				if !ok {
+					logOrderMatchMiss(t, orderMatchNoReceivableOrder, 0)
 					other = append(other, t)
 					continue
 				}
 
 				var matched bool
+				var mismatch orderMatchFailure = orderMatchNoReceivableOrder
 				for i, o := range orderList {
-					if !orderTransferMatch(o, t) {
+					if reason := orderTransferMatchReason(o, t); reason != orderMatchOK {
+						mismatch = reason
 						continue
 					}
 
 					// 订单匹配 进入确认流程
-					if err := o.MarkConfirming(t.BlockNum, t.FromAddress, t.TxHash, t.Timestamp, t.Amount); err != nil {
+					_, err := model.ClaimPaymentConfirmation(&o, model.PaymentConfirmation{
+						BlockNum: t.BlockNum,
+						From:     t.FromAddress,
+						Hash:     t.TxHash,
+						At:       t.Timestamp,
+						Amount:   t.Amount,
+					})
+					if err != nil {
+						if errors.Is(err, model.ErrOrderNoLongerReceivable) || errors.Is(err, model.ErrPaymentHashAlreadyClaimed) {
+							// Another worker has already handled this transfer or this
+							// order changed state after the snapshot was loaded. It is not
+							// non-order activity and must not trigger a false alert.
+							logOrderMatchMiss(t, orderMatchClaimFailed, o.ID)
+							matched = true
+							orders[key] = append(orderList[:i], orderList[i+1:]...)
+							break
+						}
 						log.Task.Warn("mark order confirming failed:", err)
 						continue
 					}
@@ -121,6 +150,7 @@ func orderTransferHandle(ctx context.Context) {
 				}
 
 				if !matched {
+					logOrderMatchMiss(t, mismatch, 0)
 					other = append(other, t)
 				}
 			}
@@ -138,18 +168,66 @@ func orderTransferHandle(ctx context.Context) {
 	}
 }
 
+type orderMatchFailure string
+
+const (
+	orderMatchOK                orderMatchFailure = ""
+	orderMatchNoReceivableOrder orderMatchFailure = "no_receivable_order"
+	orderMatchTradeType         orderMatchFailure = "trade_type"
+	orderMatchReceivingAddress  orderMatchFailure = "receiving_address"
+	orderMatchAmount            orderMatchFailure = "amount"
+	orderMatchPaymentTimeWindow orderMatchFailure = "payment_time_window"
+	orderMatchClaimFailed       orderMatchFailure = "payment_claim"
+)
+
 func orderTransferMatch(o model.Order, t transfer) bool {
-	if o.TradeType != t.TradeType || orderMatchAddress(o) != t.RecvAddress {
-		return false
+	return orderTransferMatchReason(o, t) == orderMatchOK
+}
+
+// orderTransferMatchReason is the canonical decision used by both the block
+// scanner and user-submitted transaction hashes. Keeping the reason lets us
+// diagnose a mismatch without silently downgrading it to a non-order payment.
+func orderTransferMatchReason(o model.Order, t transfer) orderMatchFailure {
+	if o.TradeType != t.TradeType {
+		return orderMatchTradeType
+	}
+	if !orderTransferAddressEqual(o.TradeType, orderMatchAddress(o), t.RecvAddress) {
+		return orderMatchReceivingAddress
 	}
 	if !o.AddressLocked && !amountMatch(t.Amount, o.Amount, string(o.TradeType)) {
-		return false
+		return orderMatchAmount
 	}
-	if !o.CreatedAt.Before(t.Timestamp) || !o.ExpiredAt.After(t.Timestamp) {
-		return false
+	if o.CreatedAt == nil || !o.CreatedAt.Before(t.Timestamp) || !o.ExpiredAt.After(t.Timestamp) {
+		return orderMatchPaymentTimeWindow
 	}
 
-	return true
+	return orderMatchOK
+}
+
+func orderTransferAddressEqual(tradeType model.TradeType, left, right string) bool {
+	if model.AddrCaseSens(tradeType) {
+		return left == right
+	}
+
+	return strings.EqualFold(left, right)
+}
+
+func orderTransferKey(address string, tradeType model.TradeType) string {
+	if !model.AddrCaseSens(tradeType) {
+		address = strings.ToLower(address)
+	}
+
+	return fmt.Sprintf("%s%s", address, tradeType)
+}
+
+func logOrderMatchMiss(t transfer, reason orderMatchFailure, orderID int64) {
+	if log.Task == nil {
+		return
+	}
+	log.Task.Warn(fmt.Sprintf(
+		"transfer classified as non-order: tx_hash=%s network=%s trade_type=%s recipient=%s amount=%s order_id=%d reason=%s",
+		t.TxHash, t.Network, t.TradeType, t.RecvAddress, t.Amount, orderID, reason,
+	))
 }
 
 func orderMatchAddress(o model.Order) string {
@@ -263,20 +341,22 @@ func receivableOrderStatuses() []int {
 	return []int{model.OrderStatusWaiting, model.OrderStatusExpired}
 }
 
-func getReceivableOrders() map[string][]model.Order {
+func getReceivableOrders() (map[string][]model.Order, error) {
 	var orders []model.Order
 	db := model.Db.Where("status in (?)", receivableOrderStatuses()).
 		Where("expired_at > ?", time.Now().Add(model.GetLookbackHour())).
 		Order("created_at asc")
-	db.Find(&orders)
+	if err := db.Find(&orders).Error; err != nil {
+		return nil, err
+	}
 
 	data := make(map[string][]model.Order)
 	for _, t := range orders {
-		key := orderMatchAddress(t) + string(t.TradeType)
+		key := orderTransferKey(orderMatchAddress(t), t.TradeType)
 		data[key] = append(data[key], t)
 	}
 
-	return data
+	return data, nil
 }
 
 func hasLookbackOrders(tradeType []model.TradeType) bool {

--- a/app/task/tron.go
+++ b/app/task/tron.go
@@ -31,6 +31,7 @@ var gasFreeOwnerAddress = []byte{0x41, 0x3b, 0x41, 0x50, 0x50, 0xb1, 0xe7, 0x9e,
 var gasFreeContractAddress = []byte{0x41, 0x39, 0xdd, 0x12, 0xa5, 0x4e, 0x2b, 0xab, 0x7c, 0x82, 0xaa, 0x14, 0xa1, 0xe1, 0x58, 0xb3, 0x42, 0x63, 0xd2, 0xd5, 0x10}
 var usdtTrc20ContractAddress = []byte{0x41, 0xa6, 0x14, 0xf8, 0x03, 0xb6, 0xfd, 0x78, 0x09, 0x86, 0xa4, 0x2c, 0x78, 0xec, 0x9c, 0x7f, 0x77, 0xe6, 0xde, 0xd1, 0x3c}
 var usdcTrc20ContractAddress = []byte{0x41, 0x34, 0x87, 0xb6, 0x3d, 0x30, 0xb5, 0xb2, 0xc8, 0x7f, 0xb7, 0xff, 0xa8, 0xbc, 0xfa, 0xde, 0x38, 0xea, 0xac, 0x1a, 0xbe}
+var newTronGrpcClient = utils.NewTronGrpcClient
 
 type tron struct {
 	lastBlockNum         int
@@ -83,12 +84,14 @@ func (t *tron) syncBlocksForward(context.Context) {
 	defer cancel()
 
 	if err1 != nil {
+		reportRPCFailure(conf.Tron, model.Endpoint(conf.Tron), err1)
 		log.Task.Warn("GetNowBlock2 超时：", err1)
 
 		return
 	}
 
 	var now = int(block.BlockHeader.RawData.Number)
+	model.SetChainProgress(conf.Tron, now)
 
 	// 区块高度变化过大，强制丢块重扫
 	if now-t.lastBlockNum > cast.ToInt(model.GetC(model.BlockHeightMaxDiff)) {
@@ -178,6 +181,7 @@ func (t *tron) blockParse(n any) {
 	cancel()
 	if err2 != nil {
 		conf.RecordFailure(conf.Tron)
+		reportRPCFailure(conf.Tron, model.Endpoint(conf.Tron), err2)
 		t.scheduleBlockRetry(num, 0)
 		log.Task.Warn("GetBlockByNum2 ", err2)
 
@@ -427,6 +431,7 @@ func (t *tron) tradeConfirmHandle(ctx context.Context) {
 		if o.TradeType == model.TronTrx {
 			trans, err := c.GetTransactionById(ctx, &api.BytesMessage{Value: idBytes})
 			if err != nil {
+				reportRPCFailure(conf.Tron, model.Endpoint(conf.Tron), err)
 				log.Task.Error("GetTransactionById", err)
 
 				return
@@ -441,6 +446,7 @@ func (t *tron) tradeConfirmHandle(ctx context.Context) {
 
 		info, err := c.GetTransactionInfoById(ctx, &api.BytesMessage{Value: idBytes})
 		if err != nil {
+			reportRPCFailure(conf.Tron, model.Endpoint(conf.Tron), err)
 			log.Task.Error("GetTransactionInfoById", err)
 
 			return
@@ -561,43 +567,59 @@ func tronRetryDelay(attempt int) time.Duration {
 }
 
 func (t *tron) client() (*grpc.ClientConn, error) {
-	var endpoint = model.Endpoint(conf.Tron)
+	endpoints := model.EndpointCandidates(conf.Tron)
+	if len(endpoints) == 0 {
+		return nil, fmt.Errorf("连接失败: tron rpc endpoint is empty")
+	}
 
-	t.connMu.RLock()
-	if c, ok := t.conn[endpoint]; ok {
-		state := c.GetState()
-		if state == connectivity.Ready || state == connectivity.Idle {
+	var lastErr error
+	for range endpoints {
+		endpoint := model.Endpoint(conf.Tron)
+
+		t.connMu.RLock()
+		if c, ok := t.conn[endpoint]; ok {
+			state := c.GetState()
+			if state == connectivity.Ready || state == connectivity.Idle {
+				t.connMu.RUnlock()
+
+				return c, nil
+			}
+
 			t.connMu.RUnlock()
-
-			return c, nil
+		} else {
+			t.connMu.RUnlock()
 		}
 
-		t.connMu.RUnlock()
-	} else {
-		t.connMu.RUnlock()
-	}
+		t.connMu.Lock()
+		if c, ok := t.conn[endpoint]; ok {
+			state := c.GetState()
+			if state == connectivity.Ready || state == connectivity.Idle {
+				t.connMu.Unlock()
 
-	t.connMu.Lock()
-	defer t.connMu.Unlock()
+				return c, nil
+			}
 
-	if c, ok := t.conn[endpoint]; ok {
-		state := c.GetState()
-		if state == connectivity.Ready || state == connectivity.Idle {
-
-			return c, nil
+			c.Close()
+			delete(t.conn, endpoint)
 		}
 
-		c.Close()
+		conn, err := newTronGrpcClient(endpoint, model.GetTronGridApiKeys())
+		if err == nil {
+			t.conn[endpoint] = conn
+			t.connMu.Unlock()
+			log.Task.Info("Tron gRPC 连接已建立:", endpoint)
+
+			return conn, nil
+		}
+		t.connMu.Unlock()
+
+		lastErr = err
+		reportRPCFailure(conf.Tron, endpoint, err)
 	}
 
-	conn, err := utils.NewTronGrpcClient(endpoint, model.GetTronGridApiKeys())
-	if err != nil {
-
-		return nil, fmt.Errorf("连接失败: %w", err)
+	if lastErr == nil {
+		lastErr = fmt.Errorf("unknown tron grpc error")
 	}
 
-	t.conn[endpoint] = conn
-	log.Task.Info("Tron gRPC 连接已建立:", endpoint)
-
-	return conn, nil
+	return nil, fmt.Errorf("连接失败: %w", lastErr)
 }

--- a/docs/plans/2026-07-20-payment-hash-verification.md
+++ b/docs/plans/2026-07-20-payment-hash-verification.md
@@ -1,0 +1,52 @@
+# Payment hash verification and order matching recovery
+
+## Goal
+
+Prevent valid transfers from being silently classified as non-order activity, and
+allow a payer to submit a transaction hash as an immediate verification clue for
+TRON and BSC payments.
+
+## Confirmed product behaviour
+
+- The checkout displays the transaction-hash entry point immediately; it does
+  not wait for a countdown.
+- A submitted hash is only a verification clue. The server independently checks
+  the transaction and never trusts client-provided payment details.
+- The first release supports TRON and BSC.
+
+## Security and state rules
+
+1. Verify chain success/finality data, network, asset/contract, recipient,
+   amount according to the configured matching mode, and the original order
+   payment window.
+2. Accept a matching payment made during the original payment window even if
+   the scanner has subsequently changed the order to `expired`; this preserves
+   the existing lookback recovery behaviour.
+3. Reject cancelled and unrelated orders. Repeated submissions of the same
+   matching hash for the same order are idempotent.
+4. Record a durable unique hash claim before moving an order to `confirming`,
+   so a hash cannot credit two orders. Existing confirmation and merchant
+   callback paths remain responsible for final success.
+
+## Implementation outline
+
+1. Give scanner matching a canonical evaluator that returns an explicit
+   mismatch reason. Normalize case-insensitive EVM addresses before map lookup
+   and comparison.
+2. Make an error reading receivable orders retry the transfer batch rather than
+   classifying it as non-order activity. Log missing candidates and mismatch
+   reasons with transaction/order identifiers.
+3. Reuse the canonical evaluator in submitted-hash verification. Fetch and
+   normalize transfer data through TRON gRPC or BSC JSON-RPC.
+4. Add `POST /api/v1/pay/verify-transaction`, accepting only `trade_id` and
+   `tx_hash`, then atomically claim the hash and mark the order confirming.
+5. Add the immediate hash form, request state, and localized messages to the
+   active official checkout. Backend support remains checkout-template agnostic.
+
+## Verification
+
+- Reproduce the affected TRC20 order match as a unit test.
+- Test every canonical mismatch reason and database-read failure handling.
+- Test accepted/rejected transaction lookups, duplicate claims, route results,
+  and official checkout request wiring.
+- Run targeted Go tests, then `go test ./...`.


### PR DESCRIPTION
## 背景

近期出现 Solana USDC、BSC USDT/BNB 等链上已付款但订单未被采集、未进入确认或未触发回调的情况。本 PR 补齐多链漏单恢复路径，并强化扫描与回查的失败交易过滤。

## 变更内容

- 增加已遗漏链上转账的恢复与补充验证能力；
- 改进 EVM/BSC 区块批次处理，避免不完整批次造成遗漏；
- Solana 回查跳过永久不可恢复的 slot，避免扫描状态卡死；
- Solana 自动扫描与回查拒绝执行失败的交易；
- 补充 Solana 转账元数据校验，避免错误恢复付款地址、区块号或时间；
- 补充相关回归测试。

## 影响与兼容性

- 不改变正常已入账订单的成功、回调和通知流程；
- 修复只会把符合原订单收款条件的链上转账推进到既有确认流程；
- 不直接将扫描结果标记为 success，最终状态仍由现有确认任务决定。

## 验证

- [x] `go test ./... -count=1`
- [x] 相关 Solana/BSC 回归测试
- [x] 生产构建通过